### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/Account.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/Account.java
@@ -1276,6 +1276,19 @@ public class Account extends Model {
     return true;
   }
 
+  @Override
+  public int hashCode() {
+    int result = this.label != null ? this.label.hashCode() : 0;
+    result = 31 * result + (this.openingBalance != null ? this.openingBalance.hashCode() : 0);
+    result = 31 * result + (this.currency != null ? this.currency.hashCode() : 0);
+    result = 31 * result + (this.description != null ? this.description.hashCode() : 0);
+    result = 31 * result + this.color;
+    result = 31 * result + (this.excludeFromTotals ? 1 : 0);
+    result = 31 * result + (this.type != null ? this.type.hashCode() : 0);
+    result = 31 * result + (this.grouping != null ? this.grouping.hashCode() : 0);
+    return result;
+  }
+
   /**
    * mark cleared transactions as reconciled
    *

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/Money.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/Money.java
@@ -85,6 +85,15 @@ public class Money implements Serializable {
       return false;
     return true;
   }
+
+  @Override
+  public int hashCode() {
+    int result = this.currency != null ? this.currency.hashCode() : 0;
+    result = 31 * result + (this.amountMinor != null ? this.amountMinor.hashCode() : 0);
+    result = 31 * result + this.fractionDigits;
+    return result;
+  }
+
   /**
    * @param c
    * @return getDefaultFractionDigits for a currency, unless it is -1,

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/Template.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/Template.java
@@ -408,4 +408,14 @@ public class Template extends Transaction {
       return false;
     return true;
   }
+
+  @Override
+  public int hashCode() {
+    int result = this.title != null ? this.title.hashCode() : 0;
+    result = 31 * result + (this.isTransfer ? 1 : 0);
+    result = 31 * result + (this.planId != null ? this.planId.hashCode() : 0);
+    result = 31 * result + (this.planExecutionAutomatic ? 1 : 0);
+    result = 31 * result + (this.uuid != null ? this.uuid.hashCode() : 0);
+    return result;
+  }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/Transaction.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/Transaction.java
@@ -695,6 +695,31 @@ public class Transaction extends Model {
     return true;
   }
 
+  @Override
+  public int hashCode() {
+    int result = this.comment != null ? this.comment.hashCode() : 0;
+    result = 31 * result + (this.payee != null ? this.payee.hashCode() : 0);
+    result = 31 * result + (this.referenceNumber != null ? this.referenceNumber.hashCode() : 0);
+    result = 31 * result + (this.label != null ? this.label.hashCode() : 0);
+    result = 31 * result + (this.date != null ? this.date.hashCode() : 0);
+    result = 31 * result + (this.amount != null ? this.amount.hashCode() : 0);
+    result = 31 * result + (this.transferAmount != null ? this.transferAmount.hashCode() : 0);
+    result = 31 * result + (this.catId != null ? this.catId.hashCode() : 0);
+    result = 31 * result + (this.accountId != null ? this.accountId.hashCode() : 0);
+    result = 31 * result + (this.transfer_peer != null ? this.transfer_peer.hashCode() : 0);
+    result = 31 * result + (this.transfer_account != null ? this.transfer_account.hashCode() : 0);
+    result = 31 * result + (this.methodId != null ? this.methodId.hashCode() : 0);
+    result = 31 * result + (this.methodLabel != null ? this.methodLabel.hashCode() : 0);
+    result = 31 * result + (this.parentId != null ? this.parentId.hashCode() : 0);
+    result = 31 * result + (this.payeeId != null ? this.payeeId.hashCode() : 0);
+    result = 31 * result + (this.originTemplateId != null ? this.originTemplateId.hashCode() : 0);
+    result = 31 * result + (this.originPlanInstanceId != null ? this.originPlanInstanceId.hashCode() : 0);
+    result = 31 * result + this.status;
+    result = 31 * result + (this.crStatus != null ? this.crStatus.hashCode() : 0);
+    result = 31 * result + (this.pictureUri != null ? this.pictureUri.hashCode() : 0);
+    return result;
+  }
+
   public Uri getPictureUri() {
     return pictureUri;
   }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.