### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/util/Fixture.java
+++ b/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/util/Fixture.java
@@ -34,6 +34,9 @@ public class Fixture {
   private static Account account3;
   private static Currency foreignCurrency;
 
+  private Fixture() {
+  }
+
   public static Account getAccount1() {
     return account1;
   }

--- a/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/util/Matchers.java
+++ b/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/util/Matchers.java
@@ -22,6 +22,9 @@ import static org.hamcrest.Matchers.is;
  * Created by michaeltotschnig on 01.03.16.
  */
 public class Matchers {
+  private Matchers() {
+  }
+
   public static Matcher<View> withSpinnerText(final String string) {
     checkNotNull(string);
     final CursorMatchers.CursorMatcher cursorMatcher =

--- a/myExpenses/src/main/java/com/android/calendar/EventRecurrenceFormatter.java
+++ b/myExpenses/src/main/java/com/android/calendar/EventRecurrenceFormatter.java
@@ -35,6 +35,9 @@ public class EventRecurrenceFormatter
     private static int[] mMonthRepeatByDayOfWeekIds;
     private static String[][] mMonthRepeatByDayOfWeekStrs;
 
+    private EventRecurrenceFormatter() {
+    }
+
     public static String getRepeatString(Context context, Resources r, EventRecurrence recurrence,
             boolean includeEndString) {
         String endString = "";

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/activity/CommonCommands.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/activity/CommonCommands.java
@@ -39,7 +39,10 @@ import android.util.Log;
 import android.widget.Toast;
 
 public class CommonCommands {
-  static boolean dispatchCommand(Activity ctx,int command, Object tag) {
+  private CommonCommands() {
+  }
+
+  static boolean dispatchCommand(Activity ctx, int command, Object tag) {
     Intent i;
     switch(command) {
     case R.id.RATE_COMMAND:

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/dialog/DialogUtils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/dialog/DialogUtils.java
@@ -65,6 +65,9 @@ import java.util.List;
  *
  */
 public class DialogUtils {
+  private DialogUtils() {
+  }
+
   /**
    * @return Dialog to be used from Preference,
    * and from version update

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/export/qif/QifUtils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/export/qif/QifUtils.java
@@ -34,6 +34,9 @@ public class QifUtils {
     private static final Pattern MONEY_PREFIX_PATTERN = Pattern.compile("\\D");
     private static final BigDecimal HUNDRED = new BigDecimal(100);
 
+    private QifUtils() {
+    }
+
     public static String trimFirstChar(String s) {
         return s.length() > 1 ? s.substring(1) : "";
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/preference/SharedPreferencesCompat.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/preference/SharedPreferencesCompat.java
@@ -26,6 +26,9 @@ import java.lang.reflect.Method;
  */
 public class SharedPreferencesCompat {
 
+    private SharedPreferencesCompat() {
+    }
+
     public static void apply(SharedPreferences.Editor editor) {
         android.support.v4.content.SharedPreferencesCompat.EditorCompat.getInstance().apply(editor);
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DatabaseConstants.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DatabaseConstants.java
@@ -42,7 +42,10 @@ public class DatabaseConstants {
   private static String WEEK_END;
   private static String COUNT_FROM_WEEK_START_ZERO;
 
-  public static void buildLocalized(Locale locale) {
+    private DatabaseConstants() {
+    }
+
+    public static void buildLocalized(Locale locale) {
     weekStartsOn = Integer.parseInt(MyApplication.PrefKey.GROUP_WEEK_STARTS.getString("-1"));
     if (weekStartsOn == -1)
       weekStartsOn = Utils.getFirstDayOfWeek(locale); //JAVA starts with Sunday = 1

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DbUtils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DbUtils.java
@@ -43,6 +43,9 @@ import com.android.calendar.CalendarContractCompat;
 
 public class DbUtils {
 
+  private DbUtils() {
+  }
+
   public static Result backup(File backupDir) {
     cacheEventData();
     SQLiteDatabase db = TransactionProvider.mOpenHelper.getReadableDatabase();

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/service/DailyAutoBackupScheduler.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/service/DailyAutoBackupScheduler.java
@@ -28,6 +28,9 @@ import java.util.Date;
  */
 public class DailyAutoBackupScheduler {
 
+    private DailyAutoBackupScheduler() {
+    }
+
     public static void updateAutoBackupAlarms(Context context) {
         if (MyApplication.PrefKey.AUTO_BACKUP.getBoolean(false) &&
             MyApplication.PrefKey.AUTO_BACKUP_DIRTY.getBoolean(true)) {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/Utils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/Utils.java
@@ -151,6 +151,9 @@ public class Utils {
     }
   };
 
+  private Utils() {
+  }
+
   public static boolean hasApiLevel(int checkVersion) {
     return Build.VERSION.SDK_INT >= checkVersion;
   }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/ZipUtils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/ZipUtils.java
@@ -27,6 +27,9 @@ public class ZipUtils {
 
   public static final String PICTURES = Environment.DIRECTORY_PICTURES;
 
+  private ZipUtils() {
+  }
+
   /**
    * convenience method that allows to store the pictures into the backup
    * without copying them first


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.