### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/misc/UtilsTest.java
+++ b/myExpenses/src/androidTest/java/org/totschnig/myexpenses/test/misc/UtilsTest.java
@@ -67,5 +67,8 @@ public class UtilsTest extends TestCase {
     sbap.writeToParcel(p, 0);
     p.setDataPosition(0);
     assertEquals(sbap, SparseBooleanArrayParcelable.CREATOR.createFromParcel(p));
+	if (p != null) {
+		p.recycle();
+	}
   }
 }


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis
