### PR TITLE
Fix toolbar title and subtitle delay when swiping between accounts

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/activity/MyExpenses.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/activity/MyExpenses.java
@@ -1066,6 +1066,11 @@ public class MyExpenses extends LaunchActivity implements
     boolean isHome  = mAccountsCursor.getInt(mAccountsCursor.getColumnIndex(KEY_IS_AGGREGATE)) == AggregateAccount.AGGREGATE_HOME;
     mCurrentBalance = String.format(Locale.getDefault(), "%s%s", isHome ? " ≈ " : "",
         currencyFormatter.formatCurrency(new Money(currencyContext.get(currentCurrency), balance)));
+    TransactionList currentFragment = getCurrentFragment();
+    Context currentContext = null;
+    if (currentFragment != null)
+      currentContext = currentFragment.getContext();
+    mToolbar.setTitle(Account.getInstanceFromDb(mAccountId).getLabelForScreenTitle(currentContext));
     mToolbar.setSubtitle(mCurrentBalance);
     mToolbar.setSubtitleTextColor(balance < 0 ? colorExpense : colorIncome);
   }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/fragment/TransactionList.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/fragment/TransactionList.java
@@ -1327,7 +1327,6 @@ public class TransactionList extends ContextualActionBarFragment implements
       if (!getFilter().isEmpty()) {
         addChipsBulk(filterView, Stream.of(getFilter().getCriteria()).map(criterion -> criterion.prettyPrint(getContext())).collect(Collectors.toList()));
       }
-      getActivity().setTitle(mAccount.getLabelForScreenTitle(getContext()));
       SubMenu filterMenu = searchMenu.getSubMenu();
       for (int i = 0; i < filterMenu.size(); i++) {
         MenuItem filterItem = filterMenu.getItem(i);


### PR DESCRIPTION
On the main screen, when you have multiple accounts, you can swipe left/right between the different accounts. There is a slight (500 to 1000ms) delay between the toolbar's account name title and money total subtitle when doing this. This PR fixes this.

Although `getLabelForScreenTitle()` doesn't use it, I included code to get the current context for consistency.

