### PR TITLE
Java18 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,19 @@ Code has also been contributed by:
 Build
 =====
 
-```
+```sh
 git clone --depth 1 https://github.com/mtotschnig/MyExpenses.git
 cd MyExpenses
 export ANDROID_HOME={sdk-dir}
 ./gradlew build
+```
+
+If gradlew gives you a "Failed to install the following Android SDK packages"
+error message, the packages can be installed manually with commands such as:
+
+```sh
+$ANDROID_HOME/cmdline-tools/bin/sdkmanager --install --sdk_root=$ANDROID_HOME "platforms;android-32"
+$ANDROID_HOME/cmdline-tools/bin/sdkmanager --install --sdk_root=$ANDROID_HOME "build-tools;30.0.3"
 ```
 
 Integrate

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ $ANDROID_HOME/cmdline-tools/bin/sdkmanager --install --sdk_root=$ANDROID_HOME "p
 $ANDROID_HOME/cmdline-tools/bin/sdkmanager --install --sdk_root=$ANDROID_HOME "build-tools;30.0.3"
 ```
 
+If gradlew errors out with "Could not dispatch a message to the daemon", just
+re-run the command. This can happen when the system is low on memory. The same
+is true for the "Gradle build daemon disappeared unexpectedly" error.
+
 Integrate
 =========
 My Expenses now has experimental support for inserting data from third party apps. See [TransactionsContract.java](https://github.com/mtotschnig/MyExpenses/blob/master/transactionscontract/src/main/java/org/totschnig/myexpenses/contract/TransactionsContract.java).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=512M -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
This fixes the build on systems that use java18 and adds the commands for fix common build issues that people who are new to building Android apps will likely run into. Resolves #1053 