### PR TITLE
Synchronization: Increment counters

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/sync/SyncAdapter.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/sync/SyncAdapter.kt
@@ -377,12 +377,16 @@ class SyncAdapter @JvmOverloads constructor(
                                             localChanges =
                                                 syncDelegate.collectSplits(localChanges).toMutableList()
                                         }
+                                        val localChangesWasNotEmpty = localChanges.size > 0
+                                        val remoteChangesWasNotEmpty = remoteChanges.isNotEmpty()
                                         val mergeResult: Pair<List<TransactionChange>, List<TransactionChange>> =
                                             syncDelegate.mergeChangeSets(localChanges, remoteChanges)
                                         localChanges = mergeResult.first.toMutableList()
                                         remoteChanges = mergeResult.second
                                         if (remoteChanges.isNotEmpty()) {
                                             syncDelegate.writeRemoteChangesToDb(provider, remoteChanges)
+                                        }
+                                        if (remoteChangesWasNotEmpty) {
                                             accountManager.setUserData(
                                                 account,
                                                 lastRemoteSyncKey,
@@ -398,19 +402,23 @@ class SyncAdapter @JvmOverloads constructor(
                                                     localChanges,
                                                     context
                                                 )
+                                        }
+                                        if (localChangesWasNotEmpty) {
                                             accountManager.setUserData(
                                                 account,
                                                 lastLocalSyncKey,
                                                 lastSyncedLocal.toString()
                                             )
                                             log().i("storing lastSyncedLocal: $lastSyncedLocal")
-                                            accountManager.setUserData(
-                                                account,
-                                                lastRemoteSyncKey,
-                                                lastSyncedRemote.toString()
-                                            )
-                                            log().i("storing lastSyncedRemote: $lastSyncedRemote")
-                                            successLocal2Remote = localChanges.size
+                                            if (localChanges.size > 0) {
+                                                accountManager.setUserData(
+                                                    account,
+                                                    lastRemoteSyncKey,
+                                                    lastSyncedRemote.toString()
+                                                )
+                                                log().i("storing lastSyncedRemote: $lastSyncedRemote")
+                                                successLocal2Remote = localChanges.size
+                                            }
                                         }
                                         if (!BuildConfig.DEBUG) {
                                             // on debug build for auditing purposes, we keep changes in the table


### PR DESCRIPTION
Hi @mtotschnig, This fix is the smallest change from my synchronization improvements in which you were interested. I think it will be a good start to learn how to contribute (as I am new to GitHub). Please help me if I am doing something wrong or there are additional guidelines to follow.

_Short recap:_
SyncAdapter fetches both local and remote changes since the last stored "SyncKey", then merges the two lists, and after that if an update is needed it writes the changes to the database and/or the backend. 
_About the fix:_
If the merge results in an empty change on either side, then the SyncKey currently is not updated with the processed changes. Therefore at a later sync, it will again process the same input. I think it would make sense to update the counter even if there is nothing to write, because the processing of those inputs has taken place already (marked as obsolete by another change). At the next sync run, the changes which made it obsolete are already marked as processed (therefore gone), and the obsolete change may be the only one remaining at this time, so it overwrites again the previous correctly merged value, with the value before the merge.

I am not sure how likely is it that your original mergeChangeSets() returns with an empty list, because I already have a different merge strategy, but I think it would be anyway safer to handle incrementing the numbers. I see no disadvantage of this change. Please think about it, and let me know if you do have concerns.

As my free time allows me, I will come with more pull requests (or open issues to share my thoughts) about the points I've found in the synchronization.