### PR TITLE
Fix for expenses with positive amount getting styled as normal expenses

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/Amount.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/Amount.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.dp
 import org.totschnig.myexpenses.db2.FLAG_EXPENSE
 import org.totschnig.myexpenses.db2.FLAG_INCOME
 import org.totschnig.myexpenses.db2.FLAG_NEUTRAL
-import org.totschnig.myexpenses.db2.FLAG_TRANSFER
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.model.Money
 import kotlin.math.sign
@@ -87,11 +86,17 @@ fun ColoredAmountText(
     postfix: String = "",
     type: Byte? = null
 ) {
-    val color = (type ?: when(money.amountMinor.sign) {
-        1 -> FLAG_INCOME
-        -1 -> FLAG_EXPENSE
-        else -> FLAG_NEUTRAL
-    }).asColor
+
+    val color = when {
+        type == null ||
+        type != FLAG_NEUTRAL -> when(money.amountMinor.sign) {
+            1 -> FLAG_INCOME
+            -1 -> FLAG_EXPENSE
+            else -> FLAG_NEUTRAL
+        }
+
+        else -> type
+    }.asColor
 
     Text(
         modifier = modifier

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/TransactionRenderer.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/TransactionRenderer.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -344,9 +343,12 @@ abstract class ItemRenderer(
         ColoredAmountText(
             money = if (isTransferAggregate) amount.negate() else amount,
             style = style,
-            type = if (isTransferAggregate) FLAG_NEUTRAL else when (colorSource) {
-                ColorSource.TYPE -> type
-                ColorSource.SIGN -> null
+            type = when {
+                isTransferAggregate -> FLAG_NEUTRAL
+
+                colorSource == ColorSource.TYPE -> type
+
+                else -> null
             }
         )
     }


### PR DESCRIPTION
Currently in the app, when a transaction is categorized with an expense category, even if the amount is positive, the transaction shows as an expense (Example in the image). For me at least this is very confusing, even more as in the distribution page it shows styled correctly.

This fix is just meant to style it more based in the amount than in the category, but still keeping the transfer and neutral styling.

There is an open issue about this, closes #1423

|Desciption| Screenshot |
|-----------------|---------|
| As you can see, the first transaction should be styled as an income, with green text, but it looks like a regular expense | ![Screenshot_20240220-214456](https://github.com/mtotschnig/MyExpenses/assets/51208670/ac8a23a6-0c6f-4570-91c0-855f1c102881) |
