### PR TITLE
fix: add transfer category to csv import transfers

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/io/CSVParser.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/io/CSVParser.kt
@@ -106,8 +106,10 @@ class CSVParser(
                         QifUtils.isTransferCategory(subCategory)
                     ) {
                         transaction.toAccount(subCategory.substring(1, subCategory.length - 1))
+                        transaction.category(R.string.transfer)
                     } else if (QifUtils.isTransferCategory(category)) {
                         transaction.toAccount(category.substring(1, category.length - 1))
+                        transaction.category(R.string.transfer)
                     } else {
                         val category1 = category +
                                 (subCategory.takeIf { it.isNotEmpty() }?.let { ":$it" } ?: "")


### PR DESCRIPTION
I have been trying to get the Transfers working in CSV Import. It was not working 100% because the Transfer Category was not actually assigned as described in https://github.com/mtotschnig/MyExpenses/issues/1487#issuecomment-2275288228

Here I'm trying to add the category to the transfer cases.