### PR TITLE
Quality: FileChannel.transferFrom used once can produce partial file copies

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/io/FileCopyUtils.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/io/FileCopyUtils.java
@@ -19,8 +19,16 @@ public class FileCopyUtils {
   public static boolean copy(File src, File dst) {
     try (FileInputStream srcStream = new FileInputStream(src);
          FileOutputStream dstStream = new FileOutputStream(dst)) {
-      dstStream.getChannel().transferFrom(srcStream.getChannel(), 0,
-          srcStream.getChannel().size());
+      long size = srcStream.getChannel().size();
+      long position = 0;
+      while (position < size) {
+        long transferred = dstStream.getChannel().transferFrom(
+            srcStream.getChannel(), position, size - position);
+        if (transferred <= 0) {
+          throw new IOException("Failed to transfer remaining bytes");
+        }
+        position += transferred;
+      }
       return true;
     } catch (IOException e) {
       CrashHandler.report(e);


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `myExpenses/src/main/java/org/totschnig/myexpenses/util/io/FileCopyUtils.java`.

**Context:**
`copy(File src, File dst)` performs a single `transferFrom(...)` call and assumes the full file is copied. `FileChannel.transferFrom` is not guaranteed to transfer all requested bytes in one invocation on all platforms/filesystems. This can silently create truncated destination files while still returning `true`, causing data corruption.


**Proposed fix:**
Loop until all bytes are transferred (or fail), e.g.:

public static boolean copy(File src, File dst) {
  try (FileInputStream srcStream = new FileInputStream(src);
       FileOutputStream dstStream = new FileOutputStream(dst)) {
    var in = srcStream.getChannel();
    var out = dstStream.getChannel();
    long size = in.size();
    long position = 0L;
    while (position < size) {
      long transferred = out.transferFrom(in, position, size - position);
      if (transferred <= 0) {
        throw new IOException("Failed to transfer remaining bytes");
      }
      position += transferred;
    }
    return true;
  } catch (IOException e) {
    CrashHandler.report(e);
    return false;
  }
}


**Files touched:**
- `myExpenses/src/main/java/org/totschnig/myexpenses/util/io/FileCopyUtils.java` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
