### PR TITLE
Quality: Negative startIndex causes IndexOutOfBoundsException in indexOfFrom

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/CollectionUtils.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/CollectionUtils.kt
@@ -22,9 +22,10 @@ fun <T> MutableList<T>.removeNthOccurrence(element: T, n: Int): Boolean {
 }
 
 fun <T> List<T>.indexOfFrom(element: T, startIndex: Int): Int {
-        if (startIndex >= this.size) return -1
-        val subIndex = this.subList(startIndex, this.size).indexOf(element)
-        return if (subIndex == -1) -1 else startIndex + subIndex
+        val from = startIndex.coerceAtLeast(0)
+        if (from >= this.size) return -1
+        val subIndex = this.subList(from, this.size).indexOf(element)
+        return if (subIndex == -1) -1 else from + subIndex
 }
 
 fun <T> List<T>.lastIndexOfFrom(element: T, startIndex: Int): Int {


### PR DESCRIPTION
Hi there! 👋

While going through the codebase, I noticed a minor opportunity for improvement regarding `myExpenses/src/main/java/org/totschnig/myexpenses/util/CollectionUtils.kt`.

**Context:**
`indexOfFrom` only checks `startIndex >= size`. When `startIndex < 0`, `subList(startIndex, size)` throws `IndexOutOfBoundsException`, causing a runtime crash. As a general-purpose utility extension, this should not crash on invalid indices.


**Proposed fix:**
Normalize or guard `startIndex` before calling `subList`:

fun <T> List<T>.indexOfFrom(element: T, startIndex: Int): Int {
    val from = startIndex.coerceAtLeast(0)
    if (from >= this.size) return -1
    val subIndex = this.subList(from, this.size).indexOf(element)
    return if (subIndex == -1) -1 else from + subIndex
}

**Files touched:**
- `myExpenses/src/main/java/org/totschnig/myexpenses/util/CollectionUtils.kt` (modified)

*(Note: Tested the changes locally to ensure everything works as expected. Let me know if you need any adjustments, happy to help!)*

—
**NamNV**
📍 Hanoi, Vietnam
📧 nam.nv205106@gmail.com
