### PR TITLE
Persist type of balance shown in the app bar on the transaction list

### DIFF
--- a/myExpenses/src/main/java/org/totschnig/myexpenses/activity/MyExpenses.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/activity/MyExpenses.kt
@@ -267,9 +267,9 @@ open class MyExpenses : BaseMyExpenses<MyExpensesViewModel>(), OnDialogResultLis
     }
 
     protected open fun handleSortDirection(item: MenuItem) =
-        getSortDirectionFromMenuItemId(item.itemId)?.let { (sort, direction) ->
+        getSortDirectionFromMenuItemId(item.itemId)?.let {
             if (!item.isChecked) {
-                viewModel.persistSort(sort, direction)
+                viewModel.persistSort(it)
             }
             true
         } == true

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/accounts/AccountList.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/accounts/AccountList.kt
@@ -68,7 +68,6 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.totschnig.myexpenses.R
@@ -93,7 +92,7 @@ import org.totschnig.myexpenses.compose.conditional
 import org.totschnig.myexpenses.compose.optional
 import org.totschnig.myexpenses.compose.scrollbar.LazyColumnWithScrollbar
 import org.totschnig.myexpenses.compose.scrollbar.LazyColumnWithScrollbarAndBottomPadding
-import org.totschnig.myexpenses.compose.transactions.BalanceType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.dialog.Percent
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountGrouping
@@ -891,20 +890,17 @@ fun AccountCard(
 @Composable
 fun AccountSummaryV2(
     account: BaseAccount,
-    displayBalanceType: BalanceType,
     onDisplayBalanceTypeChange: (BalanceType) -> Unit,
 ) {
 
     when (account) {
         is FullAccount -> AccountSummaryV2(
             account,
-            displayBalanceType,
             onDisplayBalanceTypeChange
         )
 
         is AggregateAccount -> AccountSummaryV2(
             account,
-            displayBalanceType,
             onDisplayBalanceTypeChange
         )
     }
@@ -913,7 +909,6 @@ fun AccountSummaryV2(
 @Composable
 fun AccountSummaryV2(
     account: FullAccount,
-    displayBalanceType: BalanceType,
     onDisplayBalanceTypeChange: (BalanceType) -> Unit,
 ) {
     val homeCurrency = LocalHomeCurrency.current
@@ -962,7 +957,7 @@ fun AccountSummaryV2(
             currency = account.currencyUnit,
             modifier = Modifier.drawSumLine(),
             formattedEquivalentAmount = account.equivalentTotal.takeIf { isFx },
-            highlight = displayBalanceType == BalanceType.TOTAL
+            highlight = account.balanceType == BalanceType.TOTAL
         ) { onDisplayBalanceTypeChange(BalanceType.TOTAL) }
     }
 
@@ -974,7 +969,7 @@ fun AccountSummaryV2(
             drawSumLine()
         },
         formattedEquivalentAmount = account.equivalentCurrentBalance.takeIf { isFx },
-        highlight = displayBalanceType == BalanceType.CURRENT,
+        highlight = account.balanceType == BalanceType.CURRENT,
         onClick = if (hasMultipleBalanceTypeOptions) {
             { onDisplayBalanceTypeChange(BalanceType.CURRENT) }
         } else null
@@ -1009,13 +1004,13 @@ fun AccountSummaryV2(
             label = R.string.total_cleared,
             amount = account.clearedTotal,
             currency = account.currencyUnit,
-            highlight = displayBalanceType == BalanceType.CLEARED,
+            highlight = account.balanceType == BalanceType.CLEARED,
         ) { onDisplayBalanceTypeChange(BalanceType.CLEARED) }
         SumRowV2(
             label = R.string.total_reconciled,
             amount = account.reconciledTotal,
             currency = account.currencyUnit,
-            highlight = displayBalanceType == BalanceType.RECONCILED,
+            highlight = account.balanceType == BalanceType.RECONCILED,
         ) { onDisplayBalanceTypeChange(BalanceType.RECONCILED) }
     }
 }
@@ -1023,7 +1018,6 @@ fun AccountSummaryV2(
 @Composable
 fun AccountSummaryV2(
     account: AggregateAccount,
-    displayBalanceType: BalanceType,
     onDisplayBalanceTypeChange: (BalanceType) -> Unit,
 ) {
     val homeCurrency = LocalHomeCurrency.current
@@ -1074,7 +1068,7 @@ fun AccountSummaryV2(
             currency = account.currencyUnit,
             modifier = Modifier.drawSumLine(),
             formattedEquivalentAmount = account.equivalentTotal.takeIf { isFx },
-            highlight = displayBalanceType == BalanceType.TOTAL
+            highlight = account.balanceType == BalanceType.TOTAL
         ) { onDisplayBalanceTypeChange(BalanceType.TOTAL) }
     }
 
@@ -1086,7 +1080,7 @@ fun AccountSummaryV2(
             drawSumLine()
         },
         formattedEquivalentAmount = account.equivalentCurrentBalance.takeIf { isFx },
-        highlight = displayBalanceType == BalanceType.CURRENT,
+        highlight = account.balanceType == BalanceType.CURRENT,
         onClick = if (hasMultipleBalanceTypeOptions) {
             { onDisplayBalanceTypeChange(BalanceType.CURRENT) }
         } else null

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/accounts/AccountList.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/accounts/AccountList.kt
@@ -89,15 +89,17 @@ import org.totschnig.myexpenses.compose.SubMenuEntry
 import org.totschnig.myexpenses.compose.TEST_TAG_ACCOUNTS
 import org.totschnig.myexpenses.compose.UiText
 import org.totschnig.myexpenses.compose.conditional
+import org.totschnig.myexpenses.compose.main.deltaLabel
+import org.totschnig.myexpenses.compose.main.validatedBalanceType
 import org.totschnig.myexpenses.compose.optional
 import org.totschnig.myexpenses.compose.scrollbar.LazyColumnWithScrollbar
 import org.totschnig.myexpenses.compose.scrollbar.LazyColumnWithScrollbarAndBottomPadding
-import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.dialog.Percent
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.AccountGroupingKey
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.model.DEFAULT_FLAG_ID
 import org.totschnig.myexpenses.provider.DataBaseAccount.Companion.AGGREGATE_HOME_CURRENCY_CODE
@@ -111,7 +113,6 @@ import org.totschnig.myexpenses.viewmodel.data.Currency
 import org.totschnig.myexpenses.viewmodel.data.FullAccount
 import java.text.DecimalFormat
 import kotlin.math.absoluteValue
-import kotlin.math.sign
 
 const val SIGMA = "Σ"
 
@@ -913,6 +914,7 @@ fun AccountSummaryV2(
 ) {
     val homeCurrency = LocalHomeCurrency.current
     val isFx = account.currency != homeCurrency.code
+    val balanceType = account.validatedBalanceType
 
     SumRowV2(
         label = R.string.opening_balance,
@@ -948,7 +950,7 @@ fun AccountSummaryV2(
         )
     }
 
-    val hasMultipleBalanceTypeOptions = account.total != null || account.type.supportsReconciliation
+    val hasMultipleBalanceTypeOptions = account.total != null || account.type.supportsReconciliation || account.criterion != null
 
     account.total?.let {
         SumRowV2(
@@ -957,7 +959,7 @@ fun AccountSummaryV2(
             currency = account.currencyUnit,
             modifier = Modifier.drawSumLine(),
             formattedEquivalentAmount = account.equivalentTotal.takeIf { isFx },
-            highlight = account.balanceType == BalanceType.TOTAL
+            highlight = balanceType == BalanceType.TOTAL
         ) { onDisplayBalanceTypeChange(BalanceType.TOTAL) }
     }
 
@@ -969,28 +971,25 @@ fun AccountSummaryV2(
             drawSumLine()
         },
         formattedEquivalentAmount = account.equivalentCurrentBalance.takeIf { isFx },
-        highlight = account.balanceType == BalanceType.CURRENT,
+        highlight = balanceType == BalanceType.CURRENT,
         onClick = if (hasMultipleBalanceTypeOptions) {
             { onDisplayBalanceTypeChange(BalanceType.CURRENT) }
         } else null
     )
 
     account.criterion?.let { criterion ->
-        val isSavingGoal = criterion.sign > 0
-        val hasReached = criterion.sign == account.currentBalance.sign &&
-                account.currentBalance.absoluteValue >= criterion.absoluteValue
         val delta = account.currentBalance - criterion
         val deltaPercent = delta.toFloat() / criterion
 
         SumRowV2(
-            label = when {
-                hasReached -> R.string.overage
-                isSavingGoal -> R.string.saving_goal_short_fall
-                else -> R.string.credit_limit_available_credit
-            },
-            amount = account.criterion - account.currentBalance,
+            label = account.deltaLabel,
+            amount = delta,
             currency = account.currencyUnit,
-            percent = deltaPercent.absoluteValue
+            percent = deltaPercent.absoluteValue,
+            highlight = balanceType == BalanceType.DELTA,
+            onClick = {
+                onDisplayBalanceTypeChange(BalanceType.DELTA)
+            }
         )
         SumRowV2(
             label = if (account.criterion > 0) R.string.saving_goal else R.string.credit_limit,
@@ -1004,13 +1003,13 @@ fun AccountSummaryV2(
             label = R.string.total_cleared,
             amount = account.clearedTotal,
             currency = account.currencyUnit,
-            highlight = account.balanceType == BalanceType.CLEARED,
+            highlight = balanceType == BalanceType.CLEARED,
         ) { onDisplayBalanceTypeChange(BalanceType.CLEARED) }
         SumRowV2(
             label = R.string.total_reconciled,
             amount = account.reconciledTotal,
             currency = account.currencyUnit,
-            highlight = account.balanceType == BalanceType.RECONCILED,
+            highlight = balanceType == BalanceType.RECONCILED,
         ) { onDisplayBalanceTypeChange(BalanceType.RECONCILED) }
     }
 }
@@ -1022,6 +1021,7 @@ fun AccountSummaryV2(
 ) {
     val homeCurrency = LocalHomeCurrency.current
     val isFx = account.currency != homeCurrency.code
+    val balanceType = account.validatedBalanceType
 
     SumRowV2(
         label = R.string.opening_balance,
@@ -1068,7 +1068,7 @@ fun AccountSummaryV2(
             currency = account.currencyUnit,
             modifier = Modifier.drawSumLine(),
             formattedEquivalentAmount = account.equivalentTotal.takeIf { isFx },
-            highlight = account.balanceType == BalanceType.TOTAL
+            highlight = balanceType == BalanceType.TOTAL
         ) { onDisplayBalanceTypeChange(BalanceType.TOTAL) }
     }
 
@@ -1080,7 +1080,7 @@ fun AccountSummaryV2(
             drawSumLine()
         },
         formattedEquivalentAmount = account.equivalentCurrentBalance.takeIf { isFx },
-        highlight = account.balanceType == BalanceType.CURRENT,
+        highlight = balanceType == BalanceType.CURRENT,
         onClick = if (hasMultipleBalanceTypeOptions) {
             { onDisplayBalanceTypeChange(BalanceType.CURRENT) }
         } else null

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/Account.ext.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/Account.ext.kt
@@ -1,5 +1,11 @@
 package org.totschnig.myexpenses.compose.main
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChangeHistory
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Functions
 import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.viewmodel.data.AggregateAccount
@@ -38,7 +44,7 @@ val BaseAccount.balanceForType: Long
         }
     }
 
-fun BaseAccount.geBalanceContentDescription(type: BalanceType): Int = when(type) {
+fun BaseAccount.getBalanceContentDescription(type: BalanceType): Int = when(type) {
     BalanceType.CURRENT -> R.string.current_balance
     BalanceType.TOTAL -> R.string.menu_aggregates
     BalanceType.CLEARED -> R.string.total_cleared
@@ -60,4 +66,13 @@ val FullAccount.deltaLabel: Int
             isSavingGoal -> R.string.saving_goal_short_fall
             else -> R.string.credit_limit_available_credit
         }
+    }
+
+val BalanceType.icon
+    get() = when(this) {
+        BalanceType.CURRENT -> Icons.Default.DragHandle
+        BalanceType.TOTAL -> Icons.Default.Functions
+        BalanceType.CLEARED -> Icons.Default.Check
+        BalanceType.RECONCILED -> Icons.Default.DoneAll
+        BalanceType.DELTA -> Icons.Default.ChangeHistory
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/Account.ext.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/Account.ext.kt
@@ -1,0 +1,63 @@
+package org.totschnig.myexpenses.compose.main
+
+import org.totschnig.myexpenses.R
+import org.totschnig.myexpenses.model.BalanceType
+import org.totschnig.myexpenses.viewmodel.data.AggregateAccount
+import org.totschnig.myexpenses.viewmodel.data.BaseAccount
+import org.totschnig.myexpenses.viewmodel.data.FullAccount
+import kotlin.math.absoluteValue
+import kotlin.math.sign
+
+val BaseAccount.validatedBalanceType
+    get() = balanceType.takeIf {
+        when (it) {
+            BalanceType.CURRENT -> true
+            BalanceType.DELTA -> (this as? FullAccount)?.criterion != null
+            BalanceType.TOTAL -> (total ?: equivalentTotal) != null
+            BalanceType.CLEARED, BalanceType.RECONCILED ->  this is FullAccount && type.supportsReconciliation
+        }
+    } ?: BalanceType.CURRENT
+
+val BaseAccount.balanceForType: Long
+    get() {
+        val type = validatedBalanceType
+        return when (this) {
+            is FullAccount -> when (type) {
+                BalanceType.CURRENT -> currentBalance
+                BalanceType.TOTAL -> total!!
+                BalanceType.CLEARED -> clearedTotal
+                BalanceType.RECONCILED -> reconciledTotal
+                BalanceType.DELTA -> delta
+            }
+
+            is AggregateAccount -> when (type) {
+                BalanceType.CURRENT -> currentBalance ?: equivalentCurrentBalance
+                BalanceType.TOTAL -> total ?: equivalentTotal
+                else -> throw IllegalStateException("Unsupported balance type for aggregate account: $type")
+            }
+        }
+    }
+
+fun BaseAccount.geBalanceContentDescription(type: BalanceType): Int = when(type) {
+    BalanceType.CURRENT -> R.string.current_balance
+    BalanceType.TOTAL -> R.string.menu_aggregates
+    BalanceType.CLEARED -> R.string.total_cleared
+    BalanceType.RECONCILED -> R.string.total_reconciled
+    BalanceType.DELTA -> (this as FullAccount).deltaLabel
+}
+
+val FullAccount.delta: Long
+    get() = currentBalance - criterion!!
+
+val FullAccount.deltaLabel: Int
+    get() {
+        require(criterion != null)
+        val isSavingGoal = criterion.sign > 0
+        val hasReached = criterion.sign == currentBalance.sign &&
+                currentBalance.absoluteValue >= criterion.absoluteValue
+        return when {
+            hasReached -> R.string.overage
+            isSavingGoal -> R.string.saving_goal_short_fall
+            else -> R.string.credit_limit_available_credit
+        }
+    }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/MainScreen.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/main/MainScreen.kt
@@ -436,7 +436,6 @@ fun MainScreenAdaptive(
                             TransactionScreen(
                                 containerColor = Color.Transparent,
                                 accounts = accounts,
-                                accountGrouping = accountGrouping,
                                 availableFilters = availableFilters,
                                 selectedAccountId = selectedAccountId,
                                 viewModel = viewModel,

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
@@ -102,8 +102,11 @@ import org.totschnig.myexpenses.compose.accounts.AccountSummaryV2
 import org.totschnig.myexpenses.compose.conditional
 import org.totschnig.myexpenses.compose.main.AppEvent
 import org.totschnig.myexpenses.compose.main.AppEventHandler
+import org.totschnig.myexpenses.compose.main.geBalanceContentDescription
+import org.totschnig.myexpenses.compose.main.balanceForType
 import org.totschnig.myexpenses.compose.main.parseMenu
 import org.totschnig.myexpenses.compose.main.rememberCollapsingTabRowState
+import org.totschnig.myexpenses.compose.main.validatedBalanceType
 import org.totschnig.myexpenses.compose.optional
 import org.totschnig.myexpenses.dialog.MenuItem
 import org.totschnig.myexpenses.model.AccountGroupingKey
@@ -112,7 +115,6 @@ import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.util.convAmount
 import org.totschnig.myexpenses.viewmodel.MyExpensesV2ViewModel
-import org.totschnig.myexpenses.viewmodel.data.AggregateAccount
 import org.totschnig.myexpenses.viewmodel.data.BaseAccount
 import org.totschnig.myexpenses.viewmodel.data.FullAccount
 import org.totschnig.myexpenses.viewmodel.data.PageAccount
@@ -488,20 +490,7 @@ private fun BalanceHeader(
         targetValue = if (isSummaryPopupVisible) 0F else 180F
     )
 
-    val validatedBalanceType = currentAccount.balanceType.takeIf {
-        when (it) {
-            BalanceType.CURRENT -> true
-            BalanceType.TOTAL -> (currentAccount.total ?: currentAccount.equivalentTotal) != null
-            BalanceType.CLEARED, BalanceType.RECONCILED -> currentAccount is FullAccount && currentAccount.type.supportsReconciliation
-        }
-    } ?: BalanceType.CURRENT
-
-
-    val displayBalance = getBalanceForType(
-        currentAccount,
-        validatedBalanceType
-    )
-
+    val displayBalance = currentAccount.balanceForType
 
     Row(
         modifier = modifier
@@ -531,12 +520,12 @@ private fun BalanceHeader(
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     AccountLabel(currentAccount, Modifier.weight(1f, fill = false))
-                    BalanceSection(validatedBalanceType, displayBalance, currentAccount)
+                    BalanceSection(displayBalance, currentAccount)
                 }
             } else {
                 Column {
                     AccountLabel(currentAccount)
-                    BalanceSection(validatedBalanceType, displayBalance, currentAccount)
+                    BalanceSection(displayBalance, currentAccount)
                 }
             }
         }
@@ -650,10 +639,10 @@ private fun AccountLabel(
 
 @Composable
 private fun BalanceSection(
-    type: BalanceType,
     balance: Long,
     account: BaseAccount,
 ) {
+    val type = account.validatedBalanceType
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.graphicsLayer(clip = false)
@@ -665,7 +654,7 @@ private fun BalanceSection(
         }
         Icon(
             imageVector = type.icon,
-            contentDescription = stringResource(type.resourceId),
+            contentDescription = stringResource(account.geBalanceContentDescription(type)),
             modifier = Modifier
                 .padding(end = 4.dp)
                 .size(12.dp),
@@ -686,23 +675,6 @@ private fun BalanceSection(
                 overflow = TextOverflow.Visible,
                 softWrap = false
             )
-        }
-    }
-}
-
-private fun getBalanceForType(account: BaseAccount, type: BalanceType): Long {
-    return when (account) {
-        is FullAccount -> when (type) {
-            BalanceType.CURRENT -> account.currentBalance
-            BalanceType.TOTAL -> account.total!!
-            BalanceType.CLEARED -> account.clearedTotal
-            BalanceType.RECONCILED -> account.reconciledTotal
-        }
-
-        is AggregateAccount -> when (type) {
-            BalanceType.CURRENT -> account.currentBalance ?: account.equivalentCurrentBalance
-            BalanceType.TOTAL -> account.total ?: account.equivalentTotal
-            else -> account.equivalentCurrentBalance
         }
     }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
@@ -1,7 +1,6 @@
 package org.totschnig.myexpenses.compose.transactions
 
 import androidx.activity.compose.BackHandler
-import androidx.annotation.StringRes
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
@@ -24,13 +23,9 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
-import androidx.compose.material.icons.filled.DoneAll
-import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.Functions
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -66,7 +61,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -112,9 +106,9 @@ import org.totschnig.myexpenses.compose.main.parseMenu
 import org.totschnig.myexpenses.compose.main.rememberCollapsingTabRowState
 import org.totschnig.myexpenses.compose.optional
 import org.totschnig.myexpenses.dialog.MenuItem
-import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.AccountGroupingKey
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.util.convAmount
 import org.totschnig.myexpenses.viewmodel.MyExpensesV2ViewModel
@@ -134,7 +128,6 @@ enum class FabStyle {
 fun TransactionScreen(
     containerColor: Color = MaterialTheme.colorScheme.background,
     accounts: List<FullAccount>,
-    accountGrouping: AccountGrouping<*>,
     availableFilters: List<AccountGroupingKey>,
     selectedAccountId: Long,
     viewModel: MyExpensesV2ViewModel,
@@ -186,8 +179,6 @@ fun TransactionScreen(
         }
     }
     val accountColor = Color(currentAccount.color(LocalResources.current))
-
-    var selectedBalanceType by rememberSaveable { mutableStateOf(BalanceType.CURRENT) }
 
     Scaffold(
         contentWindowInsets = windowInsets,
@@ -257,9 +248,8 @@ fun TransactionScreen(
                                     padding(start = 4.dp, top = 4.dp)
                                 },
                                 currentAccount = currentAccount,
-                                displayBalanceType = selectedBalanceType,
                                 onDisplayBalanceTypeChange = { newType ->
-                                    selectedBalanceType = newType
+                                    viewModel.persistBalanceType(newType)
                                 },
                                 onCopyBalance = {
                                     onEvent(AppEvent.CopyToClipBoard(it))
@@ -483,21 +473,10 @@ private fun TransactionListPage(
     pageContent(pageAccount, isCurrent)
 }
 
-enum class BalanceType(
-    @param:StringRes val resourceId: Int,
-    val icon: ImageVector,
-) {
-    CURRENT(R.string.current_balance, Icons.Default.DragHandle),
-    TOTAL(R.string.menu_aggregates, Icons.Default.Functions),
-    CLEARED(R.string.total_cleared, Icons.Default.Check),
-    RECONCILED(R.string.total_reconciled, Icons.Default.DoneAll)
-}
-
 @Composable
 private fun BalanceHeader(
     currentAccount: BaseAccount,
     modifier: Modifier = Modifier,
-    displayBalanceType: BalanceType = BalanceType.CURRENT,
     bankIcon: (@Composable (Modifier, Long) -> Unit)? = null,
     onDisplayBalanceTypeChange: (BalanceType) -> Unit = {},
     onCopyBalance: (String) -> Unit = {},
@@ -509,8 +488,8 @@ private fun BalanceHeader(
         targetValue = if (isSummaryPopupVisible) 0F else 180F
     )
 
-    val validatedBalanceType = displayBalanceType.takeIf {
-        when (displayBalanceType) {
+    val validatedBalanceType = currentAccount.balanceType.takeIf {
+        when (it) {
             BalanceType.CURRENT -> true
             BalanceType.TOTAL -> (currentAccount.total ?: currentAccount.equivalentTotal) != null
             BalanceType.CLEARED, BalanceType.RECONCILED -> currentAccount is FullAccount && currentAccount.type.supportsReconciliation
@@ -606,7 +585,6 @@ private fun BalanceHeader(
                             ) {
                                 AccountSummaryV2(
                                     currentAccount,
-                                    displayBalanceType,
                                     onDisplayBalanceTypeChange
                                 )
                                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionScreen.kt
@@ -102,7 +102,7 @@ import org.totschnig.myexpenses.compose.accounts.AccountSummaryV2
 import org.totschnig.myexpenses.compose.conditional
 import org.totschnig.myexpenses.compose.main.AppEvent
 import org.totschnig.myexpenses.compose.main.AppEventHandler
-import org.totschnig.myexpenses.compose.main.geBalanceContentDescription
+import org.totschnig.myexpenses.compose.main.getBalanceContentDescription
 import org.totschnig.myexpenses.compose.main.balanceForType
 import org.totschnig.myexpenses.compose.main.parseMenu
 import org.totschnig.myexpenses.compose.main.rememberCollapsingTabRowState
@@ -654,7 +654,7 @@ private fun BalanceSection(
         }
         Icon(
             imageVector = type.icon,
-            contentDescription = stringResource(account.geBalanceContentDescription(type)),
+            contentDescription = stringResource(account.getBalanceContentDescription(type)),
             modifier = Modifier
                 .padding(end = 4.dp)
                 .size(12.dp),

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/db2/RepositoryAccount.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/db2/RepositoryAccount.kt
@@ -12,12 +12,15 @@ import kotlinx.coroutines.flow.Flow
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.Grouping
 import org.totschnig.myexpenses.model.KEY_ACCOUNT_GROUPING
 import org.totschnig.myexpenses.model.KEY_ACCOUNT_GROUPING_GROUP
 import org.totschnig.myexpenses.model.generateUuid
+import org.totschnig.myexpenses.model.sort.TransactionSort
 import org.totschnig.myexpenses.model2.Account
 import org.totschnig.myexpenses.provider.KEY_ACCOUNTID
+import org.totschnig.myexpenses.provider.KEY_BALANCE_TYPE
 import org.totschnig.myexpenses.provider.KEY_BANK_ID
 import org.totschnig.myexpenses.provider.KEY_COLOR
 import org.totschnig.myexpenses.provider.KEY_CRITERION
@@ -46,6 +49,7 @@ import org.totschnig.myexpenses.provider.TransactionProvider
 import org.totschnig.myexpenses.provider.TransactionProvider.ACCOUNTS_AGGREGATE_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.ACCOUNTS_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.AGGREGATE_V2_URI
+import org.totschnig.myexpenses.provider.TransactionProvider.SORT_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.TRANSACTIONS_URI
 import org.totschnig.myexpenses.provider.filter.Criterion
 import org.totschnig.myexpenses.provider.getLong
@@ -220,6 +224,23 @@ fun Repository.setGrouping(accountId: Long, grouping: Grouping) {
             .appendPath(grouping.name).build(),
         null, null, null
     )
+}
+
+fun Repository.setSort(accountId: Long, transactionSort: TransactionSort) {
+    contentResolver.update(
+        ContentUris.withAppendedId(SORT_URI, accountId)
+            .buildUpon()
+            .appendPath(transactionSort.column)
+            .appendPath(transactionSort.sortDirection.name)
+            .build(),
+        null, null, null
+    )
+}
+
+fun Repository.setBalanceType(accountId: Long, balanceType: BalanceType) {
+    updateAccount(accountId) {
+        put(KEY_BALANCE_TYPE, balanceType.name)
+    }
 }
 
 fun Repository.storeExchangeRate(

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/db2/entities/Template.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/db2/entities/Template.kt
@@ -2,7 +2,6 @@ package org.totschnig.myexpenses.db2.entities
 
 import android.database.Cursor
 import org.totschnig.myexpenses.dialog.ConfirmationDialogFragment.Companion.KEY_ICON
-import org.totschnig.myexpenses.model.generateUuid
 import org.totschnig.myexpenses.provider.KEY_ACCOUNTID
 import org.totschnig.myexpenses.provider.KEY_AMOUNT
 import org.totschnig.myexpenses.provider.KEY_CATID
@@ -36,7 +35,7 @@ import org.totschnig.myexpenses.provider.getLong
 import org.totschnig.myexpenses.provider.getLongOrNull
 import org.totschnig.myexpenses.provider.getString
 import org.totschnig.myexpenses.provider.getStringOrNull
-import org.totschnig.myexpenses.util.TextUtils
+import org.totschnig.myexpenses.util.TextUtils.joinEnum
 
 /**
  * A standalone data class representing a record in the `templates` table.
@@ -162,7 +161,7 @@ data class Template(
 
         companion object {
             @JvmField
-            val JOIN: String = TextUtils.joinEnum(Action::class.java)
+            val JOIN: String = joinEnum<Action>()
         }
     }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
@@ -1,22 +1,13 @@
 package org.totschnig.myexpenses.model
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ChangeHistory
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.DoneAll
-import androidx.compose.material.icons.filled.DragHandle
-import androidx.compose.material.icons.filled.Functions
-import androidx.compose.ui.graphics.vector.ImageVector
 import org.totschnig.myexpenses.util.TextUtils.joinEnum
 
-enum class BalanceType(
-    val icon: ImageVector,
-) {
-    CURRENT(Icons.Default.DragHandle),
-    TOTAL(Icons.Default.Functions),
-    CLEARED(Icons.Default.Check),
-    RECONCILED(Icons.Default.DoneAll),
-    DELTA(Icons.Default.ChangeHistory);
+enum class BalanceType {
+    CURRENT,
+    TOTAL,
+    CLEARED,
+    RECONCILED,
+    DELTA;
 
     companion object {
         val JOIN: String = joinEnum<BalanceType>()

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
@@ -1,0 +1,25 @@
+package org.totschnig.myexpenses.model
+
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.DragHandle
+import androidx.compose.material.icons.filled.Functions
+import androidx.compose.ui.graphics.vector.ImageVector
+import org.totschnig.myexpenses.R
+import org.totschnig.myexpenses.util.TextUtils.joinEnum
+
+enum class BalanceType(
+    @param:StringRes val resourceId: Int,
+    val icon: ImageVector,
+) {
+    CURRENT(R.string.current_balance, Icons.Default.DragHandle),
+    TOTAL(R.string.menu_aggregates, Icons.Default.Functions),
+    CLEARED(R.string.total_cleared, Icons.Default.Check),
+    RECONCILED(R.string.total_reconciled, Icons.Default.DoneAll);
+
+    companion object {
+        val JOIN: String = joinEnum<BalanceType>()
+    }
+}

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/BalanceType.kt
@@ -1,23 +1,22 @@
 package org.totschnig.myexpenses.model
 
-import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ChangeHistory
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.DragHandle
 import androidx.compose.material.icons.filled.Functions
 import androidx.compose.ui.graphics.vector.ImageVector
-import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.util.TextUtils.joinEnum
 
 enum class BalanceType(
-    @param:StringRes val resourceId: Int,
     val icon: ImageVector,
 ) {
-    CURRENT(R.string.current_balance, Icons.Default.DragHandle),
-    TOTAL(R.string.menu_aggregates, Icons.Default.Functions),
-    CLEARED(R.string.total_cleared, Icons.Default.Check),
-    RECONCILED(R.string.total_reconciled, Icons.Default.DoneAll);
+    CURRENT(Icons.Default.DragHandle),
+    TOTAL(Icons.Default.Functions),
+    CLEARED(Icons.Default.Check),
+    RECONCILED(Icons.Default.DoneAll),
+    DELTA(Icons.Default.ChangeHistory);
 
     companion object {
         val JOIN: String = joinEnum<BalanceType>()

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/CrStatus.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/CrStatus.kt
@@ -30,7 +30,7 @@ enum class CrStatus(@ColorRes val color: Int, val symbol: Char?) {
 
     companion object {
         @JvmField
-        val JOIN: String = joinEnum(CrStatus::class.java)
+        val JOIN: String = joinEnum<CrStatus>()
 
         @JvmStatic
         fun fromQifName(qifName: String?) =

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/Grouping.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/Grouping.kt
@@ -6,11 +6,11 @@ import androidx.annotation.StringRes
 import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.injector
 import org.totschnig.myexpenses.provider.DatabaseConstants
-import org.totschnig.myexpenses.util.TextUtils
+import org.totschnig.myexpenses.util.TextUtils.joinEnum
 import org.totschnig.myexpenses.util.Utils
 import org.totschnig.myexpenses.util.crashreporting.CrashHandler
-import org.totschnig.myexpenses.util.ui.asDateTimeFormatter
 import org.totschnig.myexpenses.util.safeMessage
+import org.totschnig.myexpenses.util.ui.asDateTimeFormatter
 import org.totschnig.myexpenses.viewmodel.data.DateInfo
 import org.totschnig.myexpenses.viewmodel.data.Transaction2
 import java.text.SimpleDateFormat
@@ -52,7 +52,7 @@ enum class Grouping(@param:StringRes val label: Int) {
      * @param groupYear           the year of the group to display
      * @param groupSecond         the number of the group in the second dimension (day, week or month)
      * @param dateInfo            information about the current date
-     * @return a human readable String representing the group as header or activity title
+     * @return a human-readable String representing the group as header or activity title
      */
     fun getDisplayTitle(
         ctx: Context,
@@ -180,6 +180,6 @@ enum class Grouping(@param:StringRes val label: Int) {
         }
 
         @JvmField
-        val JOIN: String = TextUtils.joinEnum(Grouping::class.java)
+        val JOIN: String = joinEnum<Grouping>()
     }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/sort/Sort.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/sort/Sort.kt
@@ -59,12 +59,7 @@ enum class Sort(val commandId: Int, val isDescending: Boolean = true) {
         val accountSortLabels = listOf(R.string.label, R.string.pref_sort_order_usages, R.string.pref_sort_order_last_used, R.string.pref_sort_order_custom)
 
         @JvmStatic
-        fun fromCommandId(id: Int): Sort? {
-            for (sort in entries) {
-                if (sort.commandId == id) return sort
-            }
-            return null
-        }
+        fun fromCommandId(id: Int): Sort? = entries.find { it.commandId == id }
 
         fun preferredOrderByForTemplates(
             prefHandler: PrefHandler,

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/model/sort/TransactionSort.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/model/sort/TransactionSort.kt
@@ -5,16 +5,22 @@ import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.provider.KEY_AMOUNT
 import org.totschnig.myexpenses.provider.KEY_DATE
 
-enum class TransactionSort(val sortDirection: SortDirection) {
-    DATE_DESC(SortDirection.DESC),
-    DATE_ASC(SortDirection.ASC),
-    AMOUNT_DESC(SortDirection.DESC),
-    AMOUNT_ASC(SortDirection.ASC);
+enum class TransactionSort(val commandId: Int) {
+    DATE_DESC(R.id.SORT_BY_DATE_DESCENDING_COMMAND),
+    DATE_ASC(R.id.SORT_BY_DATE_ASCENDING_COMMAND),
+    AMOUNT_DESC(R.id.SORT_BY_AMOUNT_DESCENDING_COMMAND),
+    AMOUNT_ASC(R.id.SORT_BY_AMOUNT_ASCENDING_COMMAND);
 
     val column: String
         get() = when (this) {
             DATE_ASC, DATE_DESC -> KEY_DATE
             AMOUNT_ASC, AMOUNT_DESC -> KEY_AMOUNT
+        }
+
+    val sortDirection: SortDirection
+        get() = when (this) {
+            AMOUNT_DESC, DATE_DESC -> SortDirection.DESC
+            AMOUNT_ASC, DATE_ASC -> SortDirection.ASC
         }
 
     @get:StringRes
@@ -23,4 +29,8 @@ enum class TransactionSort(val sortDirection: SortDirection) {
             DATE_ASC, DATE_DESC -> R.string.date
             AMOUNT_ASC, AMOUNT_DESC -> R.string.amount
         }
+
+    companion object {
+        fun fromCommandId(id: Int): TransactionSort? = TransactionSort.entries.find { it.commandId == id }
+    }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
@@ -1185,7 +1185,7 @@ abstract class BaseTransactionDatabase(
     }
 
     fun SupportSQLiteDatabase.upgradeTo185() {
-        execSQL("ALTER TABLE accounts ADD COLUMN balance_type text not null check (balance_type in ('CURRENT','TOTAL','CLEARED',RECONCILED','DELTA')) default 'CURRENT'")
+        execSQL("ALTER TABLE accounts ADD COLUMN balance_type text not null check (balance_type in ('CURRENT','TOTAL','CLEARED','RECONCILED','DELTA')) default 'CURRENT'")
     }
 
     protected fun SupportSQLiteDatabase.createOrRefreshAccountTriggers() {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
@@ -15,8 +15,10 @@ import org.totschnig.myexpenses.db2.FinTsAttribute
 import org.totschnig.myexpenses.injector
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyEnum
 import org.totschnig.myexpenses.model.DEFAULT_FLAG_ID
+import org.totschnig.myexpenses.model.Grouping
 import org.totschnig.myexpenses.model.PREDEFINED_NAME_INACTIVE
 import org.totschnig.myexpenses.model.PreDefinedPaymentMethod
 import org.totschnig.myexpenses.model.generateUuid
@@ -142,6 +144,32 @@ CREATE TRIGGER category_type_move
         UPDATE $TABLE_CATEGORIES SET $KEY_TYPE = (SELECT $KEY_TYPE FROM $TABLE_CATEGORIES WHERE $KEY_ROWID = new.$KEY_PARENTID) WHERE $KEY_ROWID = new.$KEY_ROWID;
     END
 """
+
+val ACCOUNTS_CREATE =
+    """CREATE TABLE $TABLE_ACCOUNTS (
+        $KEY_ROWID integer primary key autoincrement,
+        $KEY_LABEL text not null,
+        $KEY_OPENING_BALANCE integer,
+        $KEY_DESCRIPTION text,
+        $KEY_CURRENCY text not null references $TABLE_CURRENCIES($KEY_CODE),
+        $KEY_TYPE integer references $TABLE_ACCOUNT_TYPES($KEY_ROWID) NOT NULL,
+        $KEY_COLOR integer default -3355444,
+        $KEY_GROUPING text not null check ($KEY_GROUPING in (${Grouping.JOIN})) default '${Grouping.NONE.name}',
+        $KEY_USAGES integer default 0,
+        $KEY_LAST_USED datetime,
+        $KEY_SORT_KEY integer,
+        $KEY_SYNC_ACCOUNT_NAME text,
+        $KEY_SYNC_SEQUENCE_LOCAL integer default 0,
+        $KEY_EXCLUDE_FROM_TOTALS boolean default 0,
+        $KEY_UUID text,
+        $KEY_SORT_BY text default 'date',
+        $KEY_SORT_DIRECTION text not null check ($KEY_SORT_DIRECTION in ('ASC','DESC')) default 'DESC',
+        $KEY_CRITERION integer,
+        $KEY_FLAG integer references $TABLE_ACCOUNT_FLAGS($KEY_ROWID) NOT NULL default 0,
+        $KEY_SEALED boolean default 0,
+        $KEY_DYNAMIC boolean default 0,
+        $KEY_BANK_ID integer references $TABLE_BANKS($KEY_ROWID) ON DELETE SET NULL,
+        $KEY_BALANCE_TYPE not null check ($KEY_BALANCE_TYPE in (${BalanceType.JOIN})) default '${BalanceType.CURRENT.name}');"""
 
 const val BANK_CREATE = """
 CREATE TABLE $TABLE_BANKS ($KEY_ROWID integer primary key autoincrement, $KEY_BLZ text not null, $KEY_BIC text not null, $KEY_BANK_NAME text not null, $KEY_USER_ID text not null, $KEY_VERSION interger not null, unique($KEY_BLZ, $KEY_USER_ID))

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/BaseTransactionDatabase.kt
@@ -30,7 +30,7 @@ import org.totschnig.myexpenses.util.crashreporting.CrashHandler
 import timber.log.Timber
 import kotlin.math.pow
 
-const val DATABASE_VERSION = 184
+const val DATABASE_VERSION = 185
 
 private const val RAISE_UPDATE_SEALED_DEBT = "SELECT RAISE (FAIL, 'attempt to update sealed debt');"
 private const val RAISE_INCONSISTENT_CATEGORY_HIERARCHY =
@@ -1182,6 +1182,10 @@ abstract class BaseTransactionDatabase(
             put("attribute_name", BankingAttribute.GESCHAEFTS_VORFALL.name)
             put("context", BankingAttribute.GESCHAEFTS_VORFALL.context)
         })
+    }
+
+    fun SupportSQLiteDatabase.upgradeTo185() {
+        execSQL("ALTER TABLE accounts ADD COLUMN balance_type text not null check (balance_type in ('CURRENT','TOTAL','CLEARED',RECONCILED','DELTA')) default 'CURRENT'")
     }
 
     protected fun SupportSQLiteDatabase.createOrRefreshAccountTriggers() {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/CursorExt.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/CursorExt.kt
@@ -85,6 +85,9 @@ fun Cursor.isNull(column: String) = isNull(getColumnIndexOrThrow(column))
 inline fun <reified T : Enum<T>> Cursor.getEnum(column: String, default: T) =
     enumValueOrDefault(getString(column), default)
 
+inline fun <reified T : Enum<T>> Cursor.getEnumIfExists(column: String, default: T) =
+    enumValueOrDefault(getStringIfExists(column), default)
+
 inline fun <reified T : Enum<T>> Cursor.getEnum(columnIndex: Int, default: T) =
     enumValueOrDefault(getString(columnIndex), default)
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DbConstants.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/DbConstants.kt
@@ -516,7 +516,8 @@ fun accountQueryCTE(
         KEY_HAS_CLEARED,
         KEY_LAST_USED,
         KEY_BANK_ID,
-        "$KEY_CURRENCY != '$homeCurrency' AND $dynamicExpression AS $KEY_DYNAMIC"
+        "$KEY_CURRENCY != '$homeCurrency' AND $dynamicExpression AS $KEY_DYNAMIC",
+        KEY_BALANCE_TYPE
     )
     return """
 WITH now as (

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/TransactionDatabase.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/TransactionDatabase.java
@@ -51,6 +51,7 @@ import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.TRANSF
 import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.TRANSFER_SEALED_UPDATE_TRIGGER_CREATE;
 import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.VIEW_WITH_ACCOUNT_DEFINITION;
 import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.createOrRefreshTransactionLinkedTableTriggers;
+import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.getACCOUNTS_CREATE;
 import static org.totschnig.myexpenses.provider.BaseTransactionDatabaseKt.getPRIORITIZED_PRICES_CREATE;
 import static org.totschnig.myexpenses.provider.ChangeLogTriggersKt.createOrRefreshChangeLogTriggers;
 import static org.totschnig.myexpenses.provider.ChangeLogTriggersKt.createOrRefreshEquivalentAmountTriggers;
@@ -134,34 +135,6 @@ public class TransactionDatabase extends BaseTransactionDatabase {
   public TransactionDatabase(@NonNull Context context, @NonNull PrefHandler prefHandler) {
     super(context, prefHandler);
   }
-
-  /**
-   * SQL statement for accounts TABLE
-   */
-  private static final String ACCOUNTS_CREATE =
-      "CREATE TABLE " + TABLE_ACCOUNTS + " ("
-          + KEY_ROWID + " integer primary key autoincrement, "
-          + KEY_LABEL + " text not null, "
-          + KEY_OPENING_BALANCE + " integer, "
-          + KEY_DESCRIPTION + " text, "
-          + KEY_CURRENCY + " text not null  references " + TABLE_CURRENCIES + "(" + KEY_CODE + "), "
-          + KEY_TYPE + " integer references " + TABLE_ACCOUNT_TYPES + "(" + KEY_ROWID + ") NOT NULL, "
-          + KEY_COLOR + " integer default -3355444, "
-          + KEY_GROUPING + " text not null check (" + KEY_GROUPING + " in (" + Grouping.JOIN + ")) default '" + Grouping.NONE.name() + "', "
-          + KEY_USAGES + " integer default 0,"
-          + KEY_LAST_USED + " datetime, "
-          + KEY_SORT_KEY + " integer, "
-          + KEY_SYNC_ACCOUNT_NAME + " text, "
-          + KEY_SYNC_SEQUENCE_LOCAL + " integer default 0,"
-          + KEY_EXCLUDE_FROM_TOTALS + " boolean default 0, "
-          + KEY_UUID + " text, "
-          + KEY_SORT_BY + " text default 'date', "
-          + KEY_SORT_DIRECTION + " text not null check (" + KEY_SORT_DIRECTION + " in ('ASC','DESC')) default 'DESC',"
-          + KEY_CRITERION + " integer,"
-          + KEY_FLAG + " integer references " + TABLE_ACCOUNT_FLAGS + "(" + KEY_ROWID + ") NOT NULL default 0, "
-          + KEY_SEALED + " boolean default 0,"
-          + KEY_DYNAMIC + " boolean default 0,"
-          + KEY_BANK_ID + " integer references " + TABLE_BANKS + "(" + KEY_ROWID + ") ON DELETE SET NULL);";
 
   private static final String SYNC_STATE_CREATE =
       "CREATE TABLE " + TABLE_SYNC_STATE + " ("
@@ -426,7 +399,7 @@ public class TransactionDatabase extends BaseTransactionDatabase {
     db.execSQL(CATEGORIES_CREATE);
     db.execSQL(CATEGORY_UUID_INDEX_CREATE);
     createOrRefreshCategoryMainCategoryUniqueLabel(db);
-    db.execSQL(ACCOUNTS_CREATE);
+    db.execSQL(getACCOUNTS_CREATE());
     db.execSQL(ACCOUNTS_UUID_INDEX_CREATE);
     db.execSQL(SYNC_STATE_CREATE);
     db.execSQL(ACCOUNT_TYPE_CREATE);

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/TransactionDatabase.java
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/TransactionDatabase.java
@@ -2091,6 +2091,10 @@ public class TransactionDatabase extends BaseTransactionDatabase {
           createOrRefreshViews(db);
       }
 
+      if (oldVersion < 185) {
+        upgradeTo185(db);
+      }
+
       TransactionProvider.resumeChangeTrigger(db);
     } catch (SQLException e) {
       throw new SQLiteUpgradeFailedException(oldVersion, newVersion, e);

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/provider/constants.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/provider/constants.kt
@@ -290,6 +290,8 @@ const val KEY_LATEST_EXCHANGE_RATE: String = "latest_exchange_rate"
 const val KEY_LATEST_EXCHANGE_RATE_DATE: String = "latest_exchange_rate_date"
 const val KEY_ACCOUNT_TYPE_LABEL: String = "account_type_label"
 
+const val KEY_BALANCE_TYPE: String = "balance_type"
+
 //Status constants
 /**
  * No special status

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/sync/json/TransactionChange.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/sync/json/TransactionChange.kt
@@ -90,7 +90,7 @@ data class TransactionChange(
 
         companion object {
             @JvmField
-            val JOIN: String = joinEnum(Type::class.java)
+            val JOIN: String = joinEnum<Type>()
         }
 
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/MenuUtils.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/MenuUtils.kt
@@ -20,6 +20,7 @@ import org.totschnig.myexpenses.activity.BaseActivity
 import org.totschnig.myexpenses.model.sort.SortDirection
 import org.totschnig.myexpenses.model.sort.SortDirection.ASC
 import org.totschnig.myexpenses.model.sort.SortDirection.DESC
+import org.totschnig.myexpenses.model.sort.TransactionSort
 import org.totschnig.myexpenses.provider.KEY_AMOUNT
 import org.totschnig.myexpenses.provider.KEY_DATE
 import org.totschnig.myexpenses.sync.GenericAccountService
@@ -181,22 +182,4 @@ fun configureSortDirectionMenu(
     }
 }
 
-fun getSortDirectionFromMenuItemId(id: Int) = when (id) {
-    R.id.SORT_BY_DATE_ASCENDING_COMMAND -> {
-        KEY_DATE to ASC
-    }
-
-    R.id.SORT_BY_DATE_DESCENDING_COMMAND -> {
-        KEY_DATE to DESC
-    }
-
-    R.id.SORT_BY_AMOUNT_ASCENDING_COMMAND -> {
-        KEY_AMOUNT to ASC
-    }
-
-    R.id.SORT_BY_AMOUNT_DESCENDING_COMMAND -> {
-        KEY_AMOUNT to DESC
-    }
-
-    else -> null
-}
+fun getSortDirectionFromMenuItemId(id: Int) = TransactionSort.fromCommandId(id)

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/TextUtils.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/TextUtils.kt
@@ -17,9 +17,9 @@ import java.util.EnumSet
 import java.util.Locale
 
 object TextUtils {
-    @JvmStatic
-    fun <E : Enum<E>> joinEnum(enumClass: Class<E>): String =
-        EnumSet.allOf(enumClass).joinToString(",") { "'${it.name}'" }
+
+    inline fun <reified E : Enum<E>> joinEnum(): String =
+        enumValues<E>().joinToString(",") { "'${it.name}'" }
 
     @JvmStatic
     fun concatResStrings(ctx: Context, vararg resIds: Int): String =

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/util/TextUtils.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/util/TextUtils.kt
@@ -13,7 +13,6 @@ import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.model.ContribFeature
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.util.licence.LicenceStatus
-import java.util.EnumSet
 import java.util.Locale
 
 object TextUtils {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import app.cash.copper.flow.observeQuery
+import arrow.core.Tuple4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -27,11 +28,13 @@ import org.totschnig.myexpenses.R
 import org.totschnig.myexpenses.activity.StartScreen
 import org.totschnig.myexpenses.compose.transactions.Action
 import org.totschnig.myexpenses.compose.transactions.FabStyle
+import org.totschnig.myexpenses.db2.setBalanceType
 import org.totschnig.myexpenses.dialog.MenuItem
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.AccountGroupingKey
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.model.Grouping
 import org.totschnig.myexpenses.model.sort.TransactionSort
@@ -119,6 +122,14 @@ class MyExpensesV2ViewModel(
         }
     }
 
+    val aggregateAccountBalanceType by lazy {
+        EnumPreferenceAccessor(
+            dataStore,
+            stringPreferencesKey("aggregateAccountBalanceType"),
+            BalanceType.CURRENT
+        )
+    }
+
     fun setGrouping(grouping: AccountGrouping<*>) {
         setFilter(null)
         viewModelScope.launch {
@@ -179,13 +190,12 @@ class MyExpensesV2ViewModel(
         combine(
             accountDataV2.mapNotNull { it?.getOrNull() },
             _activeFilter,
-            accountGrouping.flow.filterNotNull()
-        ) { accounts, activeFilter, accountGrouping ->
-            // Triple is used to pass these down to the flatMapLatest
-            Triple(accounts, activeFilter, accountGrouping)
-        }.flatMapLatest { (accounts, activeFilter, accountGrouping) ->
+            accountGrouping.flow.filterNotNull(),
+            aggregateAccountBalanceType.flow.filterNotNull()
+        ) { accounts, activeFilter, accountGrouping, aggregateAccountBalanceType ->
+            Tuple4(accounts, activeFilter, accountGrouping, aggregateAccountBalanceType)
+        }.flatMapLatest { (accounts, activeFilter, accountGrouping, aggregateAccountBalanceType) ->
 
-            // Combine the remaining settings flows based on the calculated key
             combine(
                 groupingMap.getValue(groupingAggregateKey(accountGrouping, activeFilter)).flow,
                 sortMap.getValue(sortAggregateKey(accountGrouping, activeFilter)).flow
@@ -219,6 +229,7 @@ class MyExpensesV2ViewModel(
                         accountGrouping = aggregateAccountGrouping,
                         sortBy = aggregateSort.column,
                         sortDirection = aggregateSort.sortDirection,
+                        balanceType = aggregateAccountBalanceType,
                         equivalentOpeningBalance = filteredForTotals.sumOf { it.equivalentOpeningBalance },
                         equivalentCurrentBalance = filteredForTotals.sumOf { it.equivalentCurrentBalance },
                         equivalentSumIncome = filteredForTotals.sumOf { it.equivalentSumIncome },
@@ -324,10 +335,17 @@ class MyExpensesV2ViewModel(
                     )
                 ).set(transactionSort)
             } else {
-                performPersistSort(transactionSort.column, transactionSort.sortDirection)
+                performPersistSort(transactionSort)
             }
         }
     }
+
+    fun persistBalanceType(balanceType: BalanceType) {
+        viewModelScope.launch(context = coroutineContext()) {
+            if (selectedAccountId.value == 0L) {
+                aggregateAccountBalanceType.set(balanceType)
+            } else {
+                repository.setBalanceType(selectedAccountId.value, balanceType)
             }
         }
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
@@ -69,6 +69,7 @@ import org.totschnig.myexpenses.db2.loadTransaction
 import org.totschnig.myexpenses.db2.saveTagsForTransaction
 import org.totschnig.myexpenses.db2.setAccountProperty
 import org.totschnig.myexpenses.db2.setGrouping
+import org.totschnig.myexpenses.db2.setSort
 import org.totschnig.myexpenses.db2.tagMapFlow
 import org.totschnig.myexpenses.db2.unarchive
 import org.totschnig.myexpenses.db2.undeleteTransaction
@@ -81,7 +82,7 @@ import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.model.Grouping
 import org.totschnig.myexpenses.model.Money
 import org.totschnig.myexpenses.model.generateUuid
-import org.totschnig.myexpenses.model.sort.SortDirection
+import org.totschnig.myexpenses.model.sort.TransactionSort
 import org.totschnig.myexpenses.model2.Bank
 import org.totschnig.myexpenses.preference.ColorSource
 import org.totschnig.myexpenses.preference.Mapper
@@ -121,7 +122,6 @@ import org.totschnig.myexpenses.provider.TransactionProvider.KEY_REPLACE
 import org.totschnig.myexpenses.provider.TransactionProvider.METHOD_SAVE_TRANSACTION_TAGS
 import org.totschnig.myexpenses.provider.TransactionProvider.QUERY_PARAMETER_MAPPED_OBJECTS
 import org.totschnig.myexpenses.provider.TransactionProvider.QUERY_PARAMETER_MERGE_CURRENCY_AGGREGATES
-import org.totschnig.myexpenses.provider.TransactionProvider.SORT_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.TRANSACTIONS_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.UNSPLIT_URI
 import org.totschnig.myexpenses.provider.TransactionProvider.URI_SEGMENT_LINK_TRANSFER
@@ -539,32 +539,25 @@ open class MyExpensesViewModel(
         }
     }
 
-    fun persistSort(sort: String, direction: SortDirection) {
+    fun persistSort(transactionSort: TransactionSort) {
         viewModelScope.launch(context = coroutineContext()) {
-            performPersistSort(sort, direction)
+            performPersistSort(transactionSort)
         }
     }
 
-    suspend fun performPersistSort(sort: String, direction: SortDirection) {
+    suspend fun performPersistSort(transactionSort: TransactionSort) {
         withContext(coroutineContext()) {
             if (selectedAccountId.value == DataBaseAccount.HOME_AGGREGATE_ID) {
-                persistSortDirectionHomeAggregate(sort, direction)
+                persistSortDirectionHomeAggregate(transactionSort)
             } else {
-                contentResolver.update(
-                    ContentUris.withAppendedId(SORT_URI, selectedAccountId.value)
-                        .buildUpon()
-                        .appendPath(sort)
-                        .appendPath(direction.name)
-                        .build(),
-                    null, null, null
-                )
+                repository.setSort(selectedAccountId.value, transactionSort)
             }
         }
     }
 
-    private fun persistSortDirectionHomeAggregate(sort: String, direction: SortDirection) {
-        prefHandler.putString(SORT_BY_AGGREGATE, sort)
-        prefHandler.putString(SORT_DIRECTION_AGGREGATE, direction.name)
+    private fun persistSortDirectionHomeAggregate(transactionSort: TransactionSort) {
+        prefHandler.putString(SORT_BY_AGGREGATE, transactionSort.column)
+        prefHandler.putString(SORT_DIRECTION_AGGREGATE, transactionSort.sortDirection.name)
         triggerAccountListRefresh()
     }
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
@@ -12,6 +12,7 @@ import org.totschnig.myexpenses.compose.accounts.SIGMA
 import org.totschnig.myexpenses.model.AccountFlag
 import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.AccountType
+import org.totschnig.myexpenses.model.BalanceType
 import org.totschnig.myexpenses.model.CurrencyContext
 import org.totschnig.myexpenses.model.CurrencyUnit
 import org.totschnig.myexpenses.model.Grouping
@@ -20,6 +21,7 @@ import org.totschnig.myexpenses.model2.AccountWithGroupingKey
 import org.totschnig.myexpenses.preference.PrefHandler
 import org.totschnig.myexpenses.provider.DataBaseAccount
 import org.totschnig.myexpenses.provider.KEY_AMOUNT
+import org.totschnig.myexpenses.provider.KEY_BALANCE_TYPE
 import org.totschnig.myexpenses.provider.KEY_BANK_ID
 import org.totschnig.myexpenses.provider.KEY_CLEARED_TOTAL
 import org.totschnig.myexpenses.provider.KEY_COLOR
@@ -81,6 +83,7 @@ sealed class BaseAccount : DataBaseAccount() {
     abstract val equivalentTotal: Long?
     abstract fun labelV2(context: Context): String
     fun aggregateColor(resources: Resources) = ResourcesCompat.getColor(resources, R.color.colorAggregate, null)
+    abstract val balanceType: BalanceType
     override val flagId: Long?
         get() = flag?.id
     override val typeId: Long?
@@ -110,7 +113,8 @@ data class AggregateAccount(
     val hasCleared: Boolean = false,
     override val total: Long? = null,
     override val equivalentTotal: Long = total ?: 0,
-    override val accountGrouping: AccountGrouping<*>
+    override val accountGrouping: AccountGrouping<*>,
+    override val balanceType: BalanceType = BalanceType.CURRENT
 ): BaseAccount() {
     override val id: Long = 0
     override val currency: String = currencyUnit.code
@@ -170,6 +174,7 @@ data class FullAccount(
     override val grouping: Grouping = Grouping.NONE,
     override val sortBy: String = KEY_DATE,
     override val sortDirection: SortDirection = SortDirection.DESC,
+    override val balanceType: BalanceType = BalanceType.CURRENT,
     val syncAccountName: String? = null,
     val reconciledTotal: Long = 0L,
     val clearedTotal: Long = 0L,
@@ -278,6 +283,7 @@ data class FullAccount(
                     getLocalDate(KEY_LATEST_EXCHANGE_RATE_DATE) to it
                 },
                 dynamic = getBoolean(KEY_DYNAMIC),
+                balanceType = getEnum(KEY_BALANCE_TYPE, BalanceType.CURRENT)
             )
         }
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
@@ -62,6 +62,8 @@ import org.totschnig.myexpenses.provider.getBoolean
 import org.totschnig.myexpenses.provider.getDouble
 import org.totschnig.myexpenses.provider.getDoubleOrNull
 import org.totschnig.myexpenses.provider.getEnum
+import org.totschnig.myexpenses.provider.getEnumIfExists
+import org.totschnig.myexpenses.provider.getEnumOrNull
 import org.totschnig.myexpenses.provider.getInt
 import org.totschnig.myexpenses.provider.getLocalDate
 import org.totschnig.myexpenses.provider.getLong
@@ -283,7 +285,7 @@ data class FullAccount(
                     getLocalDate(KEY_LATEST_EXCHANGE_RATE_DATE) to it
                 },
                 dynamic = getBoolean(KEY_DYNAMIC),
-                balanceType = getEnum(KEY_BALANCE_TYPE, BalanceType.CURRENT)
+                balanceType = getEnumIfExists(KEY_BALANCE_TYPE, BalanceType.CURRENT)
             )
         }
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/FullAccount.kt
@@ -63,7 +63,6 @@ import org.totschnig.myexpenses.provider.getDouble
 import org.totschnig.myexpenses.provider.getDoubleOrNull
 import org.totschnig.myexpenses.provider.getEnum
 import org.totschnig.myexpenses.provider.getEnumIfExists
-import org.totschnig.myexpenses.provider.getEnumOrNull
 import org.totschnig.myexpenses.provider.getInt
 import org.totschnig.myexpenses.provider.getLocalDate
 import org.totschnig.myexpenses.provider.getLong

--- a/myExpenses/src/test/java/org/totschnig/myexpenses/util/TextUtilsTest.kt
+++ b/myExpenses/src/test/java/org/totschnig/myexpenses/util/TextUtilsTest.kt
@@ -36,7 +36,7 @@ internal class TextUtilsTest {
 
     @Test
     fun joinEnum() {
-        assertThat(joinEnum(TestEnum::class.java)).isEqualTo("'One','Two','Three'")
+        assertThat(joinEnum<TestEnum>()).isEqualTo("'One','Two','Three'")
     }
 
     @Test


### PR DESCRIPTION
Previously the balance was reset when user opened a different account or restarted the app.
This PR also adds the feature of showing the delta between current balance and the criterion (credit limit / saving goal) as balance type.