### PR TITLE
Bugfix/1933 header data

### DIFF
--- a/fints/src/main/java/org/totschnig/fints/BankingViewModel.kt
+++ b/fints/src/main/java/org/totschnig/fints/BankingViewModel.kt
@@ -933,7 +933,7 @@ class BankingViewModel(application: Application) : ContentResolvingAndroidViewMo
     val banks: StateFlow<List<Bank>> by lazy {
         repository.loadBanks().stateIn(
             viewModelScope,
-            SharingStarted.WhileSubscribed(5000),
+            SharingStarted.WhileSubscribedWithTimeout,
             emptyList()
         )
     }
@@ -944,7 +944,7 @@ class BankingViewModel(application: Application) : ContentResolvingAndroidViewMo
             withAggregates = false
         ).stateIn(
             viewModelScope,
-            SharingStarted.WhileSubscribed(5000),
+            SharingStarted.WhileSubscribedWithTimeout,
             emptyList()
         )
     }

--- a/fints/src/main/java/org/totschnig/fints/BankingViewModel.kt
+++ b/fints/src/main/java/org/totschnig/fints/BankingViewModel.kt
@@ -933,7 +933,7 @@ class BankingViewModel(application: Application) : ContentResolvingAndroidViewMo
     val banks: StateFlow<List<Bank>> by lazy {
         repository.loadBanks().stateIn(
             viewModelScope,
-            SharingStarted.Lazily,
+            SharingStarted.WhileSubscribed(5000),
             emptyList()
         )
     }
@@ -944,7 +944,7 @@ class BankingViewModel(application: Application) : ContentResolvingAndroidViewMo
             withAggregates = false
         ).stateIn(
             viewModelScope,
-            SharingStarted.Lazily,
+            SharingStarted.WhileSubscribed(5000),
             emptyList()
         )
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/activity/BaseMyExpenses.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/activity/BaseMyExpenses.kt
@@ -138,6 +138,7 @@ import org.totschnig.myexpenses.viewmodel.UpgradeHandlerViewModel
 import org.totschnig.myexpenses.viewmodel.data.AggregateAccount
 import org.totschnig.myexpenses.viewmodel.data.BaseAccount
 import org.totschnig.myexpenses.viewmodel.data.FullAccount
+import org.totschnig.myexpenses.viewmodel.data.HeaderDataEmpty
 import org.totschnig.myexpenses.viewmodel.data.PageAccount
 import org.totschnig.myexpenses.viewmodel.data.Transaction2
 import org.totschnig.myexpenses.viewmodel.getNaturalComparator
@@ -1492,7 +1493,10 @@ abstract class BaseMyExpenses<T : MyExpensesViewModel> : LaunchActivity(),
                 }
             }
 
-            headerData.collectAsState().value.let { headerData ->
+            headerData.collectAsState()
+                .value
+                .takeIf { it !is HeaderDataEmpty }
+                ?.let { headerData ->
 
                 val lazyPagingItems = viewModel.getTransactions(account).collectAsLazyPagingItems()
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionList.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/compose/transactions/TransactionList.kt
@@ -126,11 +126,11 @@ data class ScrollCalculationResult(
 
 private fun LazyPagingItems<Transaction2>.getCurrentPosition(
     start: ScrollCalculationResult,
-    sortDirection: SortDirection,
-    headerData: HeaderDataResult,
+    headerData: HeaderData,
     collapsedIds: Set<String>,
 ): ScrollCalculationResult {
     var (index, visibleIndex, lastHeader) = start
+    val sortDirection = headerData.account.sortDirection
     val limit = when (sortDirection) {
         SortDirection.ASC -> LocalDateTime.now()
             .truncatedTo(ChronoUnit.DAYS)
@@ -268,12 +268,11 @@ fun TransactionList(
             mutableIntStateOf(0)
         }
 
-        if (collapsedIds != null) {
+        if (collapsedIds != null && headerData is HeaderData) {
             scrollToCurrentDateStartIndex.value?.let {
                 LaunchedEffect(lazyPagingItems.itemCount, lazyPagingItems.loadState) {
                     val scrollCalculationResult = lazyPagingItems.getCurrentPosition(
                         start = it,
-                        sortDirection = headerData.account.sortDirection,
                         headerData = headerData,
                         collapsedIds = collapsedIds
                     )

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountFlagsViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountFlagsViewModel.kt
@@ -54,7 +54,7 @@ class AccountFlagsViewModel(application: Application) : ContentResolvingAndroidV
                 editingAccountFlag = edit,
                 selectingAccountsForFlag = selection
             )
-        }.stateIn(viewModelScope, SharingStarted.Lazily, AccountFlagsUiState(isLoading = true))
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AccountFlagsUiState(isLoading = true))
     }
 
     private val aggregateInvisibleKey: Preferences.Key<Boolean>

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountFlagsViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountFlagsViewModel.kt
@@ -54,7 +54,7 @@ class AccountFlagsViewModel(application: Application) : ContentResolvingAndroidV
                 editingAccountFlag = edit,
                 selectingAccountsForFlag = selection
             )
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AccountFlagsUiState(isLoading = true))
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, AccountFlagsUiState(isLoading = true))
     }
 
     private val aggregateInvisibleKey: Preferences.Key<Boolean>

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountTypeViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountTypeViewModel.kt
@@ -32,7 +32,7 @@ class AccountTypeViewModel(application: Application) : ContentResolvingAndroidVi
                 accountTypes = accountTypes,
                 editingAccountType = editingAccountType
             )
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AccountTypesUiState(isLoading = true))
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, AccountTypesUiState(isLoading = true))
     }
 
     fun onAdd() {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountTypeViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/AccountTypeViewModel.kt
@@ -32,7 +32,7 @@ class AccountTypeViewModel(application: Application) : ContentResolvingAndroidVi
                 accountTypes = accountTypes,
                 editingAccountType = editingAccountType
             )
-        }.stateIn(viewModelScope, SharingStarted.Lazily, AccountTypesUiState(isLoading = true))
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AccountTypesUiState(isLoading = true))
     }
 
     fun onAdd() {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BaseViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BaseViewModel.kt
@@ -7,6 +7,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.SharingStarted
 import org.totschnig.myexpenses.MyApplication
 import java.util.*
 import javax.inject.Inject
@@ -29,4 +30,6 @@ abstract class BaseViewModel(application: Application) : AndroidViewModel(applic
         localizedContext.resources.getQuantityString(resId, quantity, *formatArgs)
 
     protected fun coroutineContext() = viewModelScope.coroutineContext + coroutineDispatcher
+
+    val SharingStarted.Companion.WhileSubscribedWithTimeout: SharingStarted get() = WhileSubscribed(stopTimeoutMillis = 5000)
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetListViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetListViewModel.kt
@@ -96,7 +96,7 @@ class BudgetListViewModel(application: Application) : BudgetViewModel(applicatio
                             localizedContext.getString(it.first().grouping.getLabelForBudgetType()) to it
                         }
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Grouping.Account to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, Grouping.Account to emptyList())
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetListViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetListViewModel.kt
@@ -96,7 +96,7 @@ class BudgetListViewModel(application: Application) : BudgetViewModel(applicatio
                             localizedContext.getString(it.first().grouping.getLabelForBudgetType()) to it
                         }
             }
-        }.stateIn(viewModelScope, SharingStarted.Lazily, Grouping.Account to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Grouping.Account to emptyList())
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetViewModel2.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetViewModel2.kt
@@ -121,7 +121,7 @@ class BudgetViewModel2(application: Application, savedStateHandle: SavedStateHan
     lateinit var categoryTreeForBudget: Flow<Category>
 
     val sum: StateFlow<Long> by lazy {
-        sums.map { it.second }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
+        sums.map { it.second }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, 0)
     }
 
     val sortOrder by lazy {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetViewModel2.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/BudgetViewModel2.kt
@@ -121,7 +121,7 @@ class BudgetViewModel2(application: Application, savedStateHandle: SavedStateHan
     lateinit var categoryTreeForBudget: Flow<Category>
 
     val sum: StateFlow<Long> by lazy {
-        sums.map { it.second }.stateIn(viewModelScope, SharingStarted.Lazily, 0)
+        sums.map { it.second }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
     }
 
     val sortOrder by lazy {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ContentResolvingAndroidViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ContentResolvingAndroidViewModel.kt
@@ -194,7 +194,7 @@ open class ContentResolvingAndroidViewModel(application: Application) :
     }
 
     val accountTypes by lazy {
-        accountTypesRaw.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        accountTypesRaw.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyList())
     }
 
     val accountFlagsRaw by lazy {
@@ -202,7 +202,7 @@ open class ContentResolvingAndroidViewModel(application: Application) :
     }
 
     val accountFlags by lazy {
-        repository.getAccountFlags().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        repository.getAccountFlags().stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyList())
     }
 
     sealed class DeleteState {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ContentResolvingAndroidViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ContentResolvingAndroidViewModel.kt
@@ -52,8 +52,8 @@ import org.totschnig.myexpenses.model.AccountGrouping
 import org.totschnig.myexpenses.model.CurrencyContext
 import org.totschnig.myexpenses.model.KEY_ACCOUNT_GROUPING
 import org.totschnig.myexpenses.model.KEY_ACCOUNT_GROUPING_GROUP
-import org.totschnig.myexpenses.model.generateUuid
 import org.totschnig.myexpenses.model.Money
+import org.totschnig.myexpenses.model.generateUuid
 import org.totschnig.myexpenses.model2.Account
 import org.totschnig.myexpenses.preference.ColorSource
 import org.totschnig.myexpenses.preference.PrefHandler
@@ -194,7 +194,7 @@ open class ContentResolvingAndroidViewModel(application: Application) :
     }
 
     val accountTypes by lazy {
-        accountTypesRaw.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+        accountTypesRaw.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     }
 
     val accountFlagsRaw by lazy {
@@ -202,7 +202,7 @@ open class ContentResolvingAndroidViewModel(application: Application) :
     }
 
     val accountFlags by lazy {
-        repository.getAccountFlags().stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        repository.getAccountFlags().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     }
 
     sealed class DeleteState {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/CurrencyViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/CurrencyViewModel.kt
@@ -37,7 +37,7 @@ open class CurrencyViewModel(application: Application) :
         contentResolver.observeQuery(
             TransactionProvider.DYNAMIC_CURRENCIES_URI,
         ).mapToList(dispatcher = coroutineDispatcher) { currencyContext[it.getString(0)] }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyList())
     }
 
     val currenciesFromEnum: List<Currency>

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/CurrencyViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/CurrencyViewModel.kt
@@ -37,7 +37,7 @@ open class CurrencyViewModel(application: Application) :
         contentResolver.observeQuery(
             TransactionProvider.DYNAMIC_CURRENCIES_URI,
         ).mapToList(dispatcher = coroutineDispatcher) { currencyContext[it.getString(0)] }
-            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     }
 
     val currenciesFromEnum: List<Currency>

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtOverViewViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtOverViewViewModel.kt
@@ -91,6 +91,6 @@ class DebtOverViewViewModel(application: Application) : DebtViewModel(applicatio
                     }
                 } else debts
             }
-        }.stateIn(viewModelScope, SharingStarted.Lazily, Sort.LABEL to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Sort.LABEL to emptyList())
     }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtOverViewViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtOverViewViewModel.kt
@@ -91,6 +91,6 @@ class DebtOverViewViewModel(application: Application) : DebtViewModel(applicatio
                     }
                 } else debts
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Sort.LABEL to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, Sort.LABEL to emptyList())
     }
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtViewModel.kt
@@ -71,7 +71,7 @@ open class DebtViewModel(application: Application) : PrintViewModel(application)
             null
         ).mapToOne {
             DisplayDebt.fromCursor(it, currencyContext)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
 
     private fun singleDebtUri(debtId: Long) =
         ContentUris.withAppendedId(TransactionProvider.DEBTS_URI, debtId)

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DebtViewModel.kt
@@ -71,7 +71,7 @@ open class DebtViewModel(application: Application) : PrintViewModel(application)
             null
         ).mapToOne {
             DisplayDebt.fromCursor(it, currencyContext)
-        }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     private fun singleDebtUri(debtId: Long) =
         ContentUris.withAppendedId(TransactionProvider.DEBTS_URI, debtId)

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DistributionViewModelBase.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DistributionViewModelBase.kt
@@ -132,7 +132,7 @@ abstract class DistributionViewModelBase<T : DistributionAccountInfo>(
                 Grouping.MONTH -> DateInfoExtra(11, null)
                 else -> DateInfoExtra(0, null)
             }
-        }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
     val displaySubTitle: Flow<String> = combine(
         groupingInfoFlow.filterNotNull(),

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DistributionViewModelBase.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/DistributionViewModelBase.kt
@@ -132,7 +132,7 @@ abstract class DistributionViewModelBase<T : DistributionAccountInfo>(
                 Grouping.MONTH -> DateInfoExtra(11, null)
                 else -> DateInfoExtra(0, null)
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
 
     val displaySubTitle: Flow<String> = combine(
         groupingInfoFlow.filterNotNull(),

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ManageCategoriesViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ManageCategoriesViewModel.kt
@@ -166,7 +166,7 @@ class ManageCategoriesViewModel(application: Application, savedStateHandle: Save
             withColors = false
         )
     }
-        .stateIn(viewModelScope, SharingStarted.Lazily, LoadingState.Loading)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingState.Loading)
 
     val categoryTreeForSelect: Flow<LoadingState> by lazy {
         categoryTree(sortOrder = sortOrder.value.toOrderByWithDefault(defaultSort, collate))

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ManageCategoriesViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/ManageCategoriesViewModel.kt
@@ -166,7 +166,7 @@ class ManageCategoriesViewModel(application: Application, savedStateHandle: Save
             withColors = false
         )
     }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LoadingState.Loading)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, LoadingState.Loading)
 
     val categoryTreeForSelect: Flow<LoadingState> by lazy {
         categoryTree(sortOrder = sortOrder.value.toOrderByWithDefault(defaultSort, collate))

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
@@ -196,7 +196,7 @@ class MyExpensesV2ViewModel(
             .mapToListCatching {
                 it.fromCursor(currencyContext)
             }
-            .stateIn(viewModelScope, SharingStarted.Lazily, null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -264,7 +264,7 @@ class MyExpensesV2ViewModel(
                     }
                 }
             }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -280,7 +280,7 @@ class MyExpensesV2ViewModel(
                     }
                 }
             }
-        }.stateIn(viewModelScope, SharingStarted.Lazily, null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     }
 
     val groupingMap: Map<String, PreferenceAccessor<Grouping, String>> = lazyMap {

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesV2ViewModel.kt
@@ -196,7 +196,7 @@ class MyExpensesV2ViewModel(
             .mapToListCatching {
                 it.fromCursor(currencyContext)
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -264,7 +264,7 @@ class MyExpensesV2ViewModel(
                     }
                 }
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyList())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -280,7 +280,7 @@ class MyExpensesV2ViewModel(
                     }
                 }
             }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
     }
 
     val groupingMap: Map<String, PreferenceAccessor<Grouping, String>> = lazyMap {
@@ -442,7 +442,7 @@ class MyExpensesV2ViewModel(
             .map { it ?: defaultConfiguration }
             .stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.WhileSubscribedWithTimeout,
                 initialValue = defaultConfiguration
             )
     }
@@ -451,7 +451,7 @@ class MyExpensesV2ViewModel(
         dataStore.isWebUiActive
             .stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.WhileSubscribedWithTimeout,
                 initialValue = false
             )
     }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
@@ -409,7 +409,7 @@ open class MyExpensesViewModel(
                 .build()
         ).mapToOne {
             SumInfo.fromCursor(it)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SumInfo.EMPTY)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, SumInfo.EMPTY)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -441,11 +441,11 @@ open class MyExpensesViewModel(
                     headerData?.let { HeaderData(account, it, dateInfo, filter != null) }
                         ?: HeaderDataError
                 }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HeaderDataEmpty)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, HeaderDataEmpty)
 
     protected val tags: StateFlow<Map<String, Pair<String, Int?>>> by lazy {
         contentResolver.tagMapFlow
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyMap())
     }
 
     open fun buildTransactionPagingSource(account: PageAccount) =
@@ -497,7 +497,7 @@ open class MyExpensesViewModel(
                 .map {
                     date to it
                 }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LocalDate.now() to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, LocalDate.now() to emptyList())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val debtSum: StateFlow<Long> = balanceDate.flatMapLatest { date ->
@@ -508,7 +508,7 @@ open class MyExpensesViewModel(
         ).map {
             it.fold(0L) { sum, debt -> sum + debt.currentEquivalentBalance }
         }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0L)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, 0L)
 
     val sortOrderAccounts: Sort
         get() = prefHandler.enumValueOrDefault(
@@ -527,7 +527,7 @@ open class MyExpensesViewModel(
             .mapToListCatching {
                 it.fromCursor(currencyContext)
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
     }
 
     fun headerData(account: PageAccount, v2: Boolean) = buildHeaderData(account, v2)

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/MyExpensesViewModel.kt
@@ -11,9 +11,7 @@ import android.os.Parcelable
 import android.text.TextUtils.concat
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.lifecycle.LiveData
@@ -411,7 +409,7 @@ open class MyExpensesViewModel(
                 .build()
         ).mapToOne {
             SumInfo.fromCursor(it)
-        }.stateIn(viewModelScope, SharingStarted.Lazily, SumInfo.EMPTY)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SumInfo.EMPTY)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -441,13 +439,13 @@ open class MyExpensesViewModel(
                 .flowOn(Dispatchers.IO)
                 .combine(dateInfo) { headerData, dateInfo ->
                     headerData?.let { HeaderData(account, it, dateInfo, filter != null) }
-                        ?: HeaderDataError(account)
+                        ?: HeaderDataError
                 }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HeaderDataEmpty(account))
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), HeaderDataEmpty)
 
     protected val tags: StateFlow<Map<String, Pair<String, Int?>>> by lazy {
         contentResolver.tagMapFlow
-            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
     }
 
     open fun buildTransactionPagingSource(account: PageAccount) =
@@ -499,7 +497,7 @@ open class MyExpensesViewModel(
                 .map {
                     date to it
                 }
-        }.stateIn(viewModelScope, SharingStarted.Lazily, LocalDate.now() to emptyList())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), LocalDate.now() to emptyList())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val debtSum: StateFlow<Long> = balanceDate.flatMapLatest { date ->
@@ -510,7 +508,7 @@ open class MyExpensesViewModel(
         ).map {
             it.fold(0L) { sum, debt -> sum + debt.currentEquivalentBalance }
         }
-    }.stateIn(viewModelScope, SharingStarted.Lazily, 0L)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0L)
 
     val sortOrderAccounts: Sort
         get() = prefHandler.enumValueOrDefault(
@@ -529,7 +527,7 @@ open class MyExpensesViewModel(
             .mapToListCatching {
                 it.fromCursor(currencyContext)
             }
-            .stateIn(viewModelScope, SharingStarted.Lazily, null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
     }
 
     fun headerData(account: PageAccount, v2: Boolean) = buildHeaderData(account, v2)

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PartyListViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PartyListViewModel.kt
@@ -102,7 +102,7 @@ class PartyListViewModel(
             notifyForDescendants = true
         ).mapToOne {
             it.getInt(0)
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, 0)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PartyListViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PartyListViewModel.kt
@@ -102,7 +102,7 @@ class PartyListViewModel(
             notifyForDescendants = true
         ).mapToOne {
             it.getInt(0)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, 0)
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PriceHistoryViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PriceHistoryViewModel.kt
@@ -134,7 +134,7 @@ class PriceHistoryViewModel(application: Application, val savedStateHandle: Save
                     )
                 )
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, emptyMap())
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PriceHistoryViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/PriceHistoryViewModel.kt
@@ -134,7 +134,7 @@ class PriceHistoryViewModel(application: Application, val savedStateHandle: Save
                     )
                 )
             }
-            .stateIn(viewModelScope, SharingStarted.Lazily, emptyMap())
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
     }
 
 

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/TemplateShortcutSelectViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/TemplateShortcutSelectViewModel.kt
@@ -37,5 +37,5 @@ class TemplateShortcutSelectViewModel(application: Application) :
                     it.getEnum(2, Template.Action.SAVE)
                 )
             }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribedWithTimeout, null)
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/TemplateShortcutSelectViewModel.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/TemplateShortcutSelectViewModel.kt
@@ -37,5 +37,5 @@ class TemplateShortcutSelectViewModel(application: Application) :
                     it.getEnum(2, Template.Action.SAVE)
                 )
             }
-            .stateIn(viewModelScope, SharingStarted.Lazily, null)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 }

--- a/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/HeaderData.kt
+++ b/myExpenses/src/main/java/org/totschnig/myexpenses/viewmodel/data/HeaderData.kt
@@ -19,27 +19,27 @@ import java.time.LocalDate
 
 @Immutable
 @Stable
-sealed interface HeaderDataResult {
-    val account: PageAccount
-    fun calculateGroupId(transaction: Transaction2) = account.grouping.calculateGroupId(transaction)
-}
+sealed interface HeaderDataResult
 
-data class HeaderDataEmpty(override val account: PageAccount) : HeaderDataResult
-data class HeaderDataError(override val account: PageAccount) : HeaderDataResult
+object HeaderDataEmpty : HeaderDataResult
+object HeaderDataError : HeaderDataResult
 
 data class HeaderData(
-    override val account: PageAccount,
+    val account: PageAccount,
     val groups: Map<Int, HeaderRow>,
     val dateInfo: DateInfo,
-    val isFiltered: Boolean
+    val isFiltered: Boolean,
 ) : HeaderDataResult {
+
+    fun calculateGroupId(transaction: Transaction2) = account.grouping.calculateGroupId(transaction)
+
 
     companion object {
         fun fromSequence(
             openingBalance: Long,
             grouping: Grouping,
             currency: CurrencyUnit,
-            sequence: Sequence<Cursor>
+            sequence: Sequence<Cursor>,
         ): Map<Int, HeaderRow> =
             buildMap {
                 var previousBalance = openingBalance
@@ -63,7 +63,7 @@ data class HeaderRow(
     val previousBalance: Money,
     val delta: Money,
     val interimBalance: Money,
-    val weekStart: LocalDate?
+    val weekStart: LocalDate?,
 ) {
 
     companion object {
@@ -76,7 +76,7 @@ data class HeaderRow(
             expenseSum: Long,
             transferSum: Long,
             previousBalance: Long,
-            weekStart: LocalDate?
+            weekStart: LocalDate?,
         ): HeaderRow {
             val delta = incomeSum + expenseSum + transferSum
             return HeaderRow(
@@ -111,5 +111,5 @@ data class BudgetRow(
     val headerId: Int,
     val amount: Long?,
     val rollOverPrevious: Long?,
-    val oneTime: Boolean
+    val oneTime: Boolean,
 )


### PR DESCRIPTION
Fixes # 1933 (Corrupted scroll position when swiping) by preventing HeaderDataEmpty from hitting the UI
Changes all StateFlows to use SharingStarted.WhileSubscribed