### PR TITLE
fix: Properly accent Greek translation of furniture

### DIFF
--- a/myExpenses/src/main/res/values-el/categories.xml
+++ b/myExpenses/src/main/res/values-el/categories.xml
@@ -151,7 +151,7 @@
     <!-- Subcategory under "Housing" -->
     <string name="Sub_16_3">Τηλεόραση</string>
     <!-- Subcategory under "Housing" -->
-    <string name="Sub_16_4">Επιπλα</string>
+    <string name="Sub_16_4">Έπιπλα</string>
     <!-- Subcategory under "Housing" -->
     <string name="Sub_16_5">Χρεώσεις</string>
     <!-- Subcategory under "Housing" -->


### PR DESCRIPTION
Why:
Any word in Greek that is 2 syllables or more needs to be properly accented, to show where the stress of the word, when being pronounced, is to be applied. Έπιπλα is a 3 syllable word and the stress is to be applied on the very first syllable

What
Fix the typo by replacing the starting Ε with Έ